### PR TITLE
Support etcd v2.0

### DIFF
--- a/etcd/src/jepsen/system/etcd.clj
+++ b/etcd/src/jepsen/system/etcd.clj
@@ -24,19 +24,19 @@
 (def log-file "/var/log/etcd.log")
 
 (defn peer-addr [node]
-  (str (net/ip node) ":2380"))
+  (str (name node) ":2380"))
 
 (defn addr [node]
-  (str (net/ip node) ":2380"))
+  (str (name node) ":2380"))
 
 (defn cluster-url [node]
-  (str "http://" (net/ip node) ":2380"))
+  (str "http://" (name node) ":2380"))
 
 (defn listen-client-url [node]
-  (str "http://" (net/ip node) ":2379"))
+  (str "http://" (name node) ":2379"))
 
 (defn cluster-info [node]
-  (str (name node) "=http://" (net/ip node) ":2380"))
+  (str (name node) "=http://" (name node) ":2380"))
 
 (defn peers
   "The command-line peer list for an etcd cluster."

--- a/etcd/src/jepsen/system/etcd.clj
+++ b/etcd/src/jepsen/system/etcd.clj
@@ -24,17 +24,26 @@
 (def log-file "/var/log/etcd.log")
 
 (defn peer-addr [node]
-  (str (name node) ":7001"))
+  (str (net/ip node) ":2380"))
 
 (defn addr [node]
-  (str (name node) ":4001"))
+  (str (net/ip node) ":2380"))
+
+(defn cluster-url [node]
+  (str "http://" (net/ip node) ":2380"))
+
+(defn listen-client-url [node]
+  (str "http://" (net/ip node) ":2379"))
+
+(defn cluster-info [node]
+  (str (name node) "=http://" (net/ip node) ":2380"))
 
 (defn peers
   "The command-line peer list for an etcd cluster."
   [test]
   (->> test
        :nodes
-       (map peer-addr)
+       (map cluster-info)
        (str/join ",")))
 
 (defn running?
@@ -58,14 +67,14 @@
           :--exec           binary
           :--no-close
           :--
-          :-peer-addr       (peer-addr node)
-          :-addr            (addr node)
-          :-peer-bind-addr  "0.0.0.0:7001"
-          :-bind-addr       "0.0.0.0:4001"
           :-data-dir        data-dir
           :-name            (name node)
-          (when-not (= node (core/primary test))
-            [:-peers        (peers test)])
+          :-advertise-client-urls (cluster-url node)
+          :-listen-peer-urls (cluster-url node)
+          :-listen-client-urls (listen-client-url node)
+          :-initial-advertise-peer-urls (cluster-url node)
+          :-initial-cluster-state "new"
+          :-initial-cluster (peers test)
           :>>               log-file
           (c/lit "2>&1")))
 
@@ -127,7 +136,7 @@
             (swap! running assoc node (running?)))
 
           ; And spin some more until Raft is ready
-          (let [c (v/connect (str "http://" (name node) ":4001"))]
+          (let [c (v/connect (str "http://" (name node) ":2379"))]
             (while (try+ (v/reset! c :test "ok") false
                          (catch [:status 500] e true)
                          (catch [:status 307] e true))
@@ -144,7 +153,7 @@
 (defrecord CASClient [k client]
   client/Client
   (setup! [this test node]
-    (let [client (v/connect (str "http://" (name node) ":4001"))]
+    (let [client (v/connect (str "http://" (name node) ":2379"))]
       (v/reset! client k (json/generate-string nil))
       (assoc this :client client)))
 

--- a/lxc.md
+++ b/lxc.md
@@ -123,7 +123,6 @@ Set up hostfiles on each box with hardcoded IP addresses
 
 
 ```
-127.0.0.1 localhost n1 n1.local
 ::1       localhost ip6-localhost ip6-loopback
 fe00::0   ip6-localnet
 ff00::0   ip6-mcastprefix


### PR DESCRIPTION
Newer versions of etcd have deprecated many essential command line
options for setting up a static cluster [1]. This caused exceptions
on the cluster machines and also in the Jepsen script. This patch
tweaks things so that the cluster will start up with etcd v2.0.

Note that the LXC instructions for setting up the host names are
slightly adjusted.

[1] https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#04-to-20-migration-guide