### PR TITLE
Various cleanups for Elasticsearch test

### DIFF
--- a/elasticsearch/resources/logging.yml
+++ b/elasticsearch/resources/logging.yml
@@ -1,0 +1,67 @@
+# you can override this using by setting a system property, for example -Des.logger.level=DEBUG
+es.logger.level: DEBUG
+rootLogger: ${es.logger.level}, console, file
+logger:
+  # log action execution errors for easier debugging
+  action: DEBUG
+  # reduce the logging for aws, too much is logged under the default INFO
+  com.amazonaws: WARN
+
+  # gateway
+  gateway: TRACE
+  index.gateway: TRACE
+
+  # peer shard recovery
+  #indices.recovery: DEBUG
+
+  # discovery
+  discovery: TRACE
+
+  index.search.slowlog: TRACE, index_search_slow_log_file
+  index.indexing.slowlog: TRACE, index_indexing_slow_log_file
+
+additivity:
+  index.search.slowlog: false
+  index.indexing.slowlog: false
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  # Use the following log4j-extras RollingFileAppender to enable gzip compression of log files. 
+  # For more information see https://logging.apache.org/log4j/extras/apidocs/org/apache/log4j/rolling/RollingFileAppender.html
+  #file:
+    #type: extrasRollingFile
+    #file: ${path.logs}/${cluster.name}.log
+    #rollingPolicy: timeBased
+    #rollingPolicy.FileNamePattern: ${path.logs}/${cluster.name}.log.%d{yyyy-MM-dd}.gz
+    #layout:
+      #type: pattern
+      #conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_search_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_index_search_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  index_indexing_slow_log_file:
+    type: dailyRollingFile
+    file: ${path.logs}/${cluster.name}_index_indexing_slowlog.log
+    datePattern: "'.'yyyy-MM-dd"
+    layout:
+      type: pattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"

--- a/elasticsearch/src/elasticsearch/core.clj
+++ b/elasticsearch/src/elasticsearch/core.clj
@@ -221,9 +221,8 @@
                 (esi/flush client index-name)
                 (assoc op :type :ok
                        :value (->> (esd/search client index-name "number"
-                                               :search_type "query_then_fetch"
-                                               :scroll "1m"
-                                               :size 2)
+                                               :scroll "10s"
+                                               :size 20)
                                    (esd/scroll-seq client)
                                    (map (comp :num :_source))
                                    (into (sorted-set))))

--- a/elasticsearch/src/elasticsearch/core.clj
+++ b/elasticsearch/src/elasticsearch/core.clj
@@ -161,12 +161,14 @@
   (reify db/DB
     (setup! [_ test node]
       (doto node
+        (nuke!)
         (install! version)
         (configure! test)
         (start!)))
 
     (teardown! [_ test node]
-      (nuke! node))))
+      ;; Leave system up, to collect logs, analyze post mortem, etc
+      )))
 
 (def index-name "jepsen-index")
 


### PR DESCRIPTION
This change makes four changes:

- Adding a logging configuration

In order to actually determine the root cause of issues, more verbose logging is needed. This defaults to more verbose logging for Elasticsearch and adds the ability to change it from Jepsen in the future (instead of manually by hand).

- Moving `nuke!` to *before* tests

Without this, Jepsen deletes all traces of itself after running, which makes debugging much more difficult (no logs and no data left).

- Use more reasonable settings for scroll

An optional change, but I figured I would make this change anyway.

- Wait for index to become green after creation

This is a key part of testing Elasticsearch, and clients should always do this when creating indices.

------------------------------------

Note that I was able to reproduce the failures in https://github.com/elastic/elasticsearch/issues/10426 (about half of the time) **without** these changes, however after the change which waits for green after index creation, I am no longer able to reproduce data loss with the `create-pause` test (still evaluating the other tests).