### PR TITLE
Database tests fail to compile

### DIFF
--- a/aerospike/project.clj
+++ b/aerospike/project.clj
@@ -4,5 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [jepsen "0.0.3-SNAPSHOT"]
+                 [jepsen "0.0.3"]
                  [com.aerospike/aerospike-client "3.1.0"]])

--- a/elasticsearch/project.clj
+++ b/elasticsearch/project.clj
@@ -5,5 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [clj-http "1.1.0"]
-                 [jepsen "0.0.3-SNAPSHOT"]
+                 [jepsen "0.0.3"]
                  [clojurewerkz/elastisch "2.2.0-beta2"]])

--- a/mongodb/project.clj
+++ b/mongodb/project.clj
@@ -4,6 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [jepsen "0.0.3-SNAPSHOT"]
+                 [jepsen "0.0.3"]
                  [cheshire "5.4.0"]
                  [com.novemberain/monger "2.0.0"]])


### PR DESCRIPTION
The various database tests (aerospike, elasticsearch, etc.) currently fail to compile, with something like:

```
Exception in thread "main" java.io.FileNotFoundException: Could not locate jepsen/db__init.class or jepsen/db.clj on classpath: , compiling:(elasticsearch/core.clj:1:1)
	at clojure.lang.Compiler.load(Compiler.java:7142)
```

It looks like the jepsen `0.0.3-SNAPSHOT` depedency is pulling down from clojars and is missing some required files. This PR just updates the jepsen dependency versions to `0.0.3`. Alternatively you may want to just change everything to 0.0.4-SNAPSHOT, but here's this for now.