### PR TITLE
Jepsen modularity fixes and extensions (SSH ports, NetController)

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -17,6 +17,7 @@
                   :exclusions [org.slf4j/slf4j-api
                                org.slf4j-log4j12
                                com.google.guava/guava]]]
+  :classifiers [["rabbitmq" :rabbitmq]]
   :profiles {:consul {:source-paths ["consul/src"]
                       :test-paths   ["consul/test"]
                       :dependencies [[cheshire "5.4.0"]

--- a/jepsen/src/jepsen/control.clj
+++ b/jepsen/src/jepsen/control.clj
@@ -14,6 +14,7 @@
 (def ^:dynamic *sudo*     "User to sudo to"               nil)
 (def ^:dynamic *username* "Username"                      "root")
 (def ^:dynamic *password* "Password (for login and sudo)" "root")
+(def ^:dynamic *port*     "SSH listening port"            22)
 (def ^:dynamic *private-key-path*         "SSH identity file"     nil)
 (def ^:dynamic *strict-host-key-checking* "Verify SSH host keys"  :yes)
 
@@ -187,6 +188,7 @@
                        host
                        {:username *username*
                         :password *password*
+                        :port *port*
                         :strict-host-key-checking *strict-host-key-checking*})
       (ssh/connect))))
 
@@ -204,6 +206,7 @@
   [ssh & body]
   `(binding [*username*         (get ~ssh :username *username*)
              *password*         (get ~ssh :password *password*)
+             *port*             (get ~ssh :port *port*)
              *private-key-path* (get ~ssh :private-key-path *private-key-path*)
              *strict-host-key-checking* (get ~ssh :strict-host-key-checking
                                              *strict-host-key-checking*)]

--- a/jepsen/src/jepsen/core.clj
+++ b/jepsen/src/jepsen/core.clj
@@ -253,6 +253,7 @@
   :ssh        SSH credential information: a map containing...
     :username           The username to connect with   (root)
     :password           The password to use
+    :port               SSH listening port (22)
     :private-key-path   A path to an SSH identity file (~/.ssh/id_rsa)
     :strict-host-key-checking  Whether or not to verify host keys
   :os         The operating system; given by the OS protocol

--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -4,7 +4,6 @@
             [jepsen.util        :as util]
             [jepsen.client      :as client]
             [jepsen.control     :as c]
-            [jepsen.control.net :as controlnet]
             [jepsen.net         :as net]))
 
 (defn noop
@@ -15,25 +14,20 @@
     (invoke! [this test op] op)
     (teardown! [this test] this)))
 
-(defn snub-node!
-  "Drops all packets from node."
-  [net node]
-  (net/drop-from! net (controlnet/ip node)))
-
 (defn snub-nodes!
   "Drops all packets from the given nodes."
-  [net nodes]
-  (dorun (map (partial snub-node! net) nodes)))
+  [test dest sources]
+  (doseq [src sources] (net/drop! (:net test) test src dest)))
 
 (defn partition!
   "Takes a *grudge*: a map of nodes to the collection of nodes they should
   reject messages from, and makes the appropriate changes. Does not heal the
   network first, so repeated calls to partition! are cumulative right now."
-  [net grudge]
+  [test grudge]
   (->> grudge
        (map (fn [[node frenemies]]
               (future
-                (c/on node (snub-nodes! net frenemies)))))
+                (snub-nodes! test node frenemies))))
        doall
        (map deref)
        dorun))
@@ -82,19 +76,19 @@
   [grudge]
   (reify client/Client
     (setup! [this test _]
-      (c/on-many (:nodes test) (net/heal! (:net test)))
+      (net/heal! (:net test) test)
       this)
 
     (invoke! [this test op]
       (case (:f op)
         :start (let [grudge (grudge (:nodes test))]
-                 (partition! (:net test) grudge)
+                 (partition! test grudge)
                  (assoc op :value (str "Cut off " (pr-str grudge))))
-        :stop  (do (c/on-many (:nodes test) (net/heal! (:net test)))
+        :stop  (do (net/heal! (:net test) test)
                    (assoc op :value "fully connected"))))
 
     (teardown! [this test]
-      (c/on-many (:nodes test) (net/heal! (:net test))))))
+      (net/heal! (:net test) test))))
 
 (defn partition-halves
   "Responds to a :start operation by cutting the network into two halves--first

--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -17,7 +17,7 @@
 (defn snub-nodes!
   "Drops all packets from the given nodes."
   [test dest sources]
-  (doseq [src sources] (net/drop! (:net test) test src dest)))
+  (->> sources (pmap #(net/drop! (:net test) test % dest)) dorun))
 
 (defn partition!
   "Takes a *grudge*: a map of nodes to the collection of nodes they should

--- a/jepsen/src/jepsen/net.clj
+++ b/jepsen/src/jepsen/net.clj
@@ -1,20 +1,20 @@
-(ns jepsen.netcontrol
+(ns jepsen.net
   "Controls network manipulation."
   (:use jepsen.control))
 
-(defprotocol NetController
+(defprotocol Net
   (drop-from! [net source] "Drop traffic originating from this source IP.")
   (heal!      [net]        "Remove all partition-inducing rules."))
 
 (def noop
-  "Does nothing"
-  (reify NetController
+  "Does nothing."
+  (reify Net
     (drop-from! [net source])
     (heal!      [net])))
 
 (def iptables
   "Default iptables (assumes we control everything)."
-  (reify NetController
+  (reify Net
     (drop-from! [net source]
       (su (exec :iptables :-A :INPUT :-s source :-j :DROP)))
 

--- a/jepsen/src/jepsen/netcontrol.clj
+++ b/jepsen/src/jepsen/netcontrol.clj
@@ -1,0 +1,24 @@
+(ns jepsen.netcontrol
+  "Controls network manipulation."
+  (:use jepsen.control))
+
+(defprotocol NetController
+  (drop-from! [net source] "Drop traffic originating from this source IP.")
+  (heal!      [net]        "Remove all partition-inducing rules."))
+
+(def noop
+  "Does nothing"
+  (reify NetController
+    (drop-from! [net source])
+    (heal!      [net])))
+
+(def iptables
+  "Default iptables (assumes we control everything)."
+  (reify NetController
+    (drop-from! [net source]
+      (su (exec :iptables :-A :INPUT :-s source :-j :DROP)))
+
+    (heal!      [net]
+      (su
+        (exec :iptables :-F)
+        (exec :iptables :-X)))))

--- a/jepsen/src/jepsen/store.clj
+++ b/jepsen/src/jepsen/store.clj
@@ -96,7 +96,7 @@
 (defn save!
   "Writes a test to disk. Returns test."
   [test]
-  (let [test (dissoc test :db :os :netcontroller :client :checker :nemesis :generator :model)
+  (let [test (dissoc test :db :os :net :client :checker :nemesis :generator :model)
         path (path test)]
     (io/make-parents path)
     (with-open [file   (io/output-stream path)

--- a/jepsen/src/jepsen/store.clj
+++ b/jepsen/src/jepsen/store.clj
@@ -96,7 +96,7 @@
 (defn save!
   "Writes a test to disk. Returns test."
   [test]
-  (let [test (dissoc test :db :os :client :checker :nemesis :generator :model)
+  (let [test (dissoc test :db :os :netcontroller :client :checker :nemesis :generator :model)
         path (path test)]
     (io/make-parents path)
     (with-open [file   (io/output-stream path)

--- a/jepsen/src/jepsen/tests.clj
+++ b/jepsen/src/jepsen/tests.clj
@@ -7,7 +7,7 @@
             [jepsen.generator :as gen]
             [jepsen.model :as model]
             [jepsen.checker :as checker]
-            [jepsen.netcontrol :as netcontrol]))
+            [jepsen.net :as net]))
 
 
 (def noop-test
@@ -17,7 +17,7 @@
   {:nodes     [:n1 :n2 :n3 :n4 :n5]
    :os        os/noop
    :db        db/noop
-   :netcontroller netcontrol/iptables
+   :net       net/iptables
    :client    client/noop
    :nemesis   client/noop
    :generator gen/void

--- a/jepsen/src/jepsen/tests.clj
+++ b/jepsen/src/jepsen/tests.clj
@@ -6,7 +6,8 @@
             [jepsen.client :as client]
             [jepsen.generator :as gen]
             [jepsen.model :as model]
-            [jepsen.checker :as checker]))
+            [jepsen.checker :as checker]
+            [jepsen.netcontrol :as netcontrol]))
 
 
 (def noop-test
@@ -16,6 +17,7 @@
   {:nodes     [:n1 :n2 :n3 :n4 :n5]
    :os        os/noop
    :db        db/noop
+   :netcontroller netcontrol/iptables
    :client    client/noop
    :nemesis   client/noop
    :generator gen/void

--- a/jepsen/src/jepsen/tests.clj
+++ b/jepsen/src/jepsen/tests.clj
@@ -9,7 +9,6 @@
             [jepsen.checker :as checker]
             [jepsen.net :as net]))
 
-
 (def noop-test
   "Boring test stub.
   Typically used as a basis for writing more complex tests.

--- a/jepsen/test/jepsen/store_test.clj
+++ b/jepsen/test/jepsen/store_test.clj
@@ -11,7 +11,7 @@
 (deftest roundtrip-test
   (delete! "store-test")
 
-  (let [t (core/run! (assoc core-test/noop-test
+  (let [t (core/run! (assoc noop-test
                             :name     "store-test"
                             :multiset (into (multiset/multiset)
                                             [1 1 2 3 5 8])))]
@@ -21,4 +21,4 @@
       (is (= 1 (count ts)))
       (is (string? k))
       (is (= @t'
-             (dissoc t :db :os :client :checker :nemesis :generator :model))))))
+             (dissoc t :db :os :netcontroller :client :checker :nemesis :generator :model))))))

--- a/jepsen/test/jepsen/store_test.clj
+++ b/jepsen/test/jepsen/store_test.clj
@@ -21,4 +21,4 @@
       (is (= 1 (count ts)))
       (is (string? k))
       (is (= @t'
-             (dissoc t :db :os :netcontroller :client :checker :nemesis :generator :model))))))
+             (dissoc t :db :os :net :client :checker :nemesis :generator :model))))))


### PR DESCRIPTION
If you have scrunchyface opinions about the netcontrol/NetControl and :netcontroller names, I'm totally open to changing them without too much complaint. I just saw that we had control/net.clj and net.clj and (reify net/Net) and net-the-module-shortname and :net-the-test-map-hash-key, all referencing slightly different things, and I got concerned about short names costing more than they benefitted.