### PR TITLE
Add -y option to systemd package removal

### DIFF
--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -105,7 +105,7 @@
 
         ; Fucking systemd breaks a bunch of packages
         (if (installed? :systemd)
-          (c/exec :apt-get :remove :--purge :--auto-remove :systemd)))
+          (c/exec :apt-get :remove :-y :--purge :--auto-remove :systemd)))
 
       (meh (net/heal)))
 


### PR DESCRIPTION

When running jepsen using lxc-containers (a .la `sudo lxc-create -n n{1,2,3,4,5} -t debian -- --release jessie`) on an ubuntu 14.04.1 host, attempts to remove systemd from the containers fails (for aerospike at least).

After applying the -y option, I still get the following error on my first run of `lein test`:

```
Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be REMOVED:
  systemd*
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 13.8 MB disk space will be freed.
(Reading database ... 13395 files and directories currently installed.)
Removing systemd (215-17) ...
systemd is the active init system, please switch to another before removing systemd.
dpkg: error processing package systemd (--purge):
 subprocess installed pre-removal script returned error exit status 1
Failed to stop lib-init-rw.mount: Unit lib-init-rw.mount not loaded.
Failed to execute operation: File exists
Errors were encountered while processing:
 systemd
```

but subsequent test-runs will not encounter this error.

