### PR TITLE
Docker container support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM kojiromike/dind
+MAINTAINER jake@apache.org
+
+ENV JEPSEN_GIT_URL http://github.com/riptano/jepsen
+ENV LEIN_ROOT true
+
+
+#
+# Jepsen dependencies
+#
+RUN apt-get -y -q install software-properties-common 
+RUN add-apt-repository ppa:openjdk-r/ppa
+RUN apt-get -y -q update
+
+RUN apt-get install -qqy \
+    openjdk-8-jdk \
+    libjna-java \
+    git \
+    gnuplot \
+    wget
+
+
+RUN cd / && wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && mv /lein /usr/bin 
+RUN chmod +x /usr/bin/lein
+
+RUN git clone $JEPSEN_GIT_URL /jepsen
+RUN cd /jepsen/jepsen && lein install
+
+
+ADD ./build-dockerized-jepsen.sh /usr/local/bin/build-dockerized-jepsen.sh
+RUN chmod +x /usr/local/bin/build-dockerized-jepsen.sh
+
+ADD ./bashrc /root/.bashrc
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,8 @@
 FROM kojiromike/dind
 MAINTAINER jake@apache.org
 
-ENV JEPSEN_GIT_URL http://github.com/riptano/jepsen
+ENV JEPSEN_GIT_URL http://github.com/aphyr/jepsen
 ENV LEIN_ROOT true
-
 
 #
 # Jepsen dependencies

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,7 +21,7 @@ The image building is a multi-step process. Mainly because [docker doesn't let y
 1.  From this directory run 
 
     ````
-	docker build . -t jepsen
+	docker build -t jepsen .
     ````
 
 2.  Start the container and run build-dockerized-jepsen.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,15 +7,35 @@ It is intended to be used by a CI tool or anyone with docker who wants to try je
 It contains all the jepsen dependencies and code. It uses [docker-in-docker](https://github.com/jpetazzo/dind) to spin up the five
 containers used by Jepsen.  
 
-To start run
+To start run (note the required --privileged flag)
 
 ````
     docker run --privileged -t -i tjake/jepsen
 ````
 
+Building the docker image
+=========================
 
+The image building is a multi-step process. Mainly because [docker doesn't let you build with --privileged operations](https://github.com/docker/docker/issues/1916)
 
+1.  From this directory run 
 
+    ````
+	docker build . -t jepsen
+    ````
+
+2.  Start the container and run build-dockerized-jepsen.sh
+    ````
+    docker run --privileged -t -i jepsen
+
+    > build-dockerized-jepsen.sh
+    ````
+
+3.  From another window commit the updated image
+
+    ````
+    docker commit {above container-id} jepsen 
+    ````
 
 
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+Dockerized Jepsen
+=================
+
+This docker image attempts to simplify the setup required by Jepsen.
+It is intended to be used by a CI tool or anyone with docker who wants to try jepsen themselves.
+
+It contains all the jepsen dependencies and code. It uses [docker-in-docker](https://github.com/jpetazzo/dind) to spin up the five
+containers used by Jepsen.  
+
+To start run
+
+````
+    docker run --privileged -t -i tjake/jepsen
+````
+
+
+
+
+
+
+

--- a/docker/bashrc
+++ b/docker/bashrc
@@ -1,0 +1,69 @@
+
+if [ -f ~/.ssh/id_rsa.pub ] && [ ! -f ~/.started ];
+then
+
+#import the image
+cat /root/jepsennode.tar.gz | docker import - jepsennode
+
+# start the 5 nodes
+docker run --privileged -d --name n1 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+docker run --privileged -d --name n2 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+docker run --privileged -d --name n3 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+docker run --privileged -d --name n4 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+docker run --privileged -d --name n5 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+
+# note the ip address and add to /etc/hosts
+N1_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' n1)
+N2_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' n2)
+N3_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' n3)
+N4_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' n4)
+N5_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' n5)
+
+N1_ID=$(docker inspect --format '{{ .Config.Hostname }}' n1)
+N2_ID=$(docker inspect --format '{{ .Config.Hostname }}' n2)
+N3_ID=$(docker inspect --format '{{ .Config.Hostname }}' n3)
+N4_ID=$(docker inspect --format '{{ .Config.Hostname }}' n4)
+N5_ID=$(docker inspect --format '{{ .Config.Hostname }}' n5)
+
+cat <<EOF > /etc/hosts
+127.0.0.1   localhost
+::1     localhost ip6-localhost ip6-loopback
+$N1_IP n1 $N1_ID
+$N2_IP n2 $N2_ID
+$N3_IP n3 $N3_ID
+$N4_IP n4 $N4_ID
+$N5_IP n5 $N5_ID
+EOF
+
+#setup ssh known_hosts
+ssh-keyscan -t rsa n1 > ~/.ssh/known_hosts
+ssh-keyscan -t rsa n2 >> ~/.ssh/known_hosts
+ssh-keyscan -t rsa n3 >> ~/.ssh/known_hosts
+ssh-keyscan -t rsa n4 >> ~/.ssh/known_hosts
+ssh-keyscan -t rsa n5 >> ~/.ssh/known_hosts
+
+scp /etc/hosts n1:/etc/hosts
+scp /etc/hosts n2:/etc/hosts
+scp /etc/hosts n3:/etc/hosts
+scp /etc/hosts n4:/etc/hosts
+scp /etc/hosts n5:/etc/hosts
+
+echo ""
+
+cat <<EOF 
+Welcome to Jepsen on Docker
+===========================
+
+This container runs the Jepsen tests in sub-containers.
+
+You are currently in the base dir of the git repo for Jepsen.
+If you modify the core jepsen library make sure you "lein install" it so other tests can access.
+
+To run a test:
+   cd elasticsearch && lein test 
+EOF
+
+cd /jepsen
+
+fi
+

--- a/docker/bashrc
+++ b/docker/bashrc
@@ -2,6 +2,8 @@
 if [ -f ~/.ssh/id_rsa.pub ] && [ ! -f ~/.started ];
 then
 
+touch ~/.started
+
 #import the image
 cat /root/jepsennode.tar.gz | docker import - jepsennode
 

--- a/docker/build-dockerized-jepsen.sh
+++ b/docker/build-dockerized-jepsen.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+#gen sshkey
+ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+
+#start one node and install deps
+docker run -d --name n1 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" tutum/debian:jessie
+N1_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' n1)
+
+sleep 10
+
+ssh $N1_IP "rm /etc/apt/apt.conf.d/docker-clean && apt-get update && apt-get install sudo net-tools wget sysvinit-core sysvinit sysvinit-utils curl vim man faketime unzip iptables iputils-ping logrotate && apt-get remove -y --purge --auto-remove systemd" 
+
+docker export n1 > /root/jepsennode.tar
+gzip /root/jepsennode.tar
+


### PR DESCRIPTION
We need a simple way to run Jepsen (with all it's setup) in a single shot.

This creates a docker-in-docker container with all the n1-n5, ssh config, etc setup on container start, so all that's left to-do is to run the test.
