### PR TITLE
Update noop-test to use nemesis/noop

### DIFF
--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -6,9 +6,8 @@
             [jepsen.control     :as c]
             [jepsen.net         :as net]))
 
-(defn noop
+(def noop
   "Does nothing."
-  []
   (reify client/Client
     (setup! [this test node] this)
     (invoke! [this test op] op)

--- a/jepsen/src/jepsen/tests.clj
+++ b/jepsen/src/jepsen/tests.clj
@@ -4,6 +4,7 @@
   (:require [jepsen.os :as os]
             [jepsen.db :as db]
             [jepsen.client :as client]
+            [jepsen.nemesis :as nemesis]
             [jepsen.generator :as gen]
             [jepsen.model :as model]
             [jepsen.checker :as checker]
@@ -18,7 +19,7 @@
    :db        db/noop
    :net       net/iptables
    :client    client/noop
-   :nemesis   client/noop
+   :nemesis   nemesis/noop
    :generator gen/void
    :model     model/noop
    :checker   checker/linearizable})


### PR DESCRIPTION
Previously, noop-test used client/noop.

Client/noop assocs :type :ok on the argument op, which breaks the pairing in the timeline/html checker when used with noop-test.

This pull request updates noop-test to use nemesis/noop and makes nemesis/noop a def rather than a defn for consistency.