### PR TITLE
Ensure that SSH bindings are conveyed into jepsen.core/with-resources start calls.

### DIFF
--- a/jepsen/src/jepsen/core.clj
+++ b/jepsen/src/jepsen/core.clj
@@ -313,7 +313,7 @@
 
       ; Open SSH conns
       (control/with-ssh (:ssh test)
-        (with-resources [sessions control/session control/disconnect
+        (with-resources [sessions (bound-fn* control/session) control/disconnect
                          (:nodes test)]
 
           ; Index sessions by node name and add to test


### PR DESCRIPTION
Fixes issue #60.