### PR TITLE
Update Jepsen docker setup to support reuse of Jepsen containers.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,7 @@ To start run (note the required --privileged flag)
 Building the docker image
 =========================
 
-The image building is a multi-step process. Mainly because [docker doesn't let you build with --privileged operations](https://github.com/docker/docker/issues/1916)
+Alternatively, you can build the image yourself. This is a multi-step process, mainly because [docker doesn't let you build with --privileged operations](https://github.com/docker/docker/issues/1916)
 
 1.  From this directory run 
 
@@ -25,6 +25,7 @@ The image building is a multi-step process. Mainly because [docker doesn't let y
     ````
 
 2.  Start the container and run build-dockerized-jepsen.sh
+
     ````
     docker run --privileged -t -i jepsen
 
@@ -34,8 +35,11 @@ The image building is a multi-step process. Mainly because [docker doesn't let y
 3.  From another window commit the updated image
 
     ````
-    docker commit {above container-id} jepsen 
+    docker commit {above container-id} jepsen
     ````
+    
+4.  With the final image created, you can create a container to run Jepsen from
 
-
-
+    ```
+    docker run --privileged -t -i jepsen
+    ```

--- a/docker/bashrc
+++ b/docker/bashrc
@@ -1,18 +1,30 @@
-
-if [ -f ~/.ssh/id_rsa.pub ] && [ ! -f ~/.started ];
+if [ -f ~/.ssh/id_rsa.pub ];
 then
 
-touch ~/.started
+  if [ ! -f ~/.started ];
+  then
 
-#import the image
-cat /root/jepsennode.tar.gz | docker import - jepsennode
+    touch ~/.started
 
-# start the 5 nodes
-docker run --privileged -d --name n1 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
-docker run --privileged -d --name n2 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
-docker run --privileged -d --name n3 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
-docker run --privileged -d --name n4 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
-docker run --privileged -d --name n5 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+    #import the image
+    cat /root/jepsennode.tar.gz | docker import - jepsennode
+
+    # start the 5 nodes
+    docker run --privileged -d --name n1 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+    docker run --privileged -d --name n2 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+    docker run --privileged -d --name n3 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+    docker run --privileged -d --name n4 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+    docker run --privileged -d --name n5 -e ROOT_PASS="root" -e AUTHORIZED_KEYS="`cat ~/.ssh/id_rsa.pub`" jepsennode /run.sh
+
+  else
+
+    docker ps | grep -qw n1 || docker start n1
+    docker ps | grep -qw n2 || docker start n2
+    docker ps | grep -qw n3 || docker start n3
+    docker ps | grep -qw n4 || docker start n4
+    docker ps | grep -qw n5 || docker start n5
+
+  fi
 
 # note the ip address and add to /etc/hosts
 N1_IP=$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' n1)
@@ -68,4 +80,3 @@ EOF
 cd /jepsen
 
 fi
-


### PR DESCRIPTION
This change allows a jepsen container to be reused (after a stop/start) by re-running any needed sub-container setup at each login.