### PR TITLE
RethinkDB Test

### DIFF
--- a/rdb/project.clj
+++ b/rdb/project.clj
@@ -1,8 +1,6 @@
-(defproject mongodb "0.1.0-SNAPSHOT"
+(defproject rethinkdb "0.1.0-SNAPSHOT"
   :description "RethinkDB Jepsen Tests"
-;  :url "http://github.com/rethinkdb/jepsen"
-;  :license {:name "Eclipse Public License"
-;            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :url "http://github.com/rethinkdb/jepsen"
   :dependencies [[org.clojure/clojure "1.6.0"]
 
                  ;; [rethinkdb "0.9.40-SNAPSHOT"]

--- a/rdb/project.clj
+++ b/rdb/project.clj
@@ -1,0 +1,10 @@
+(defproject mongodb "0.1.0-SNAPSHOT"
+  :description "RethinkDB Jepsen Tests"
+;  :url "http://github.com/rethinkdb/jepsen"
+;  :license {:name "Eclipse Public License"
+;            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [rethinkdb "0.7.39"]
+                 [jepsen "0.0.3"]
+                 [cheshire "5.4.0"]])
+

--- a/rdb/project.clj
+++ b/rdb/project.clj
@@ -4,7 +4,14 @@
 ;  :license {:name "Eclipse Public License"
 ;            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [rethinkdb "0.7.39"]
+
+                 ;; [rethinkdb "0.9.40-SNAPSHOT"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [org.clojure/data.json "0.2.6"]
+                 [org.flatland/protobuf "0.8.1"]
+                 [rethinkdb-protobuf "0.3.0"]
+                 [clj-time "0.9.0"]
+
                  [jepsen "0.0.3"]
                  [cheshire "5.4.0"]])
 

--- a/rdb/resources/setup.sh
+++ b/rdb/resources/setup.sh
@@ -1,0 +1,19 @@
+# # Add a 100ms delay to help find edge cases.
+# tc qdisc add dev eth0 root netem delay 100ms \
+#   || tc qdisc change dev eth0 root netem delay 100ms
+rm -rf /root/rethinkdb_data
+base=http://download.rethinkdb.com/apt/pool
+version=/precise/main/r/rethinkdb/rethinkdb_2.1.5~0precise_amd64.deb
+if [[ ! -f /root/rdb.deb ]]; then
+  curl $base/$version > /root/rdb.deb
+  dpkg -i /root/rdb.deb
+fi
+# JOINLINE should be defined by whatever slurps this script.
+nohup /usr/bin/rethinkdb --bind all -n `hostname` $JOINLINE \
+  >/root/1.out 2>/root/2.out &
+sleep 1 # Wait to make sure we've actually cleared out `1.out` and `2.out`.
+# Wait until we see /^Server ready/ in the log file.
+tail -n+0 -F /root/1.out \
+  | grep --line-buffered '^Server ready' \
+  | while read line; do pkill -P $$ tail; exit 0; done
+sleep 1 # You never know.

--- a/rdb/resources/teardown.sh
+++ b/rdb/resources/teardown.sh
@@ -1,0 +1,13 @@
+# Uncomment this if you uncomment the matching line in setup.sh.
+# tc qdisc change dev eth0 root netem delay 0ms
+killall rethinkdb
+f=0
+# Wait for all rethinkdb instances to go away.
+while [[ "`ps auxww | grep rethinkdb | grep -v grep`" ]] && [[ "$f" -lt 10 ]]; do
+  sleep 1
+  f=$((f+1))
+done
+# If it takes more than 10 seconds, murder them.
+if [[ "$f" -ge 10 ]]; then
+  killall -9 rethinkdb
+fi

--- a/rdb/src/rdb/core.clj
+++ b/rdb/src/rdb/core.clj
@@ -42,8 +42,8 @@
 #tc qdisc add dev eth0 root netem delay 100ms \\
 #  || tc qdisc change dev eth0 root netem delay 100ms
 rm -rf /root/rethinkdb_data
-base=http://download.rethinkdb.com/dev
-version=/2.1.0-0BETA2/rethinkdb_2.1.0%2b0BETA2~0precise_amd64.deb
+base=http://download.rethinkdb.com/apt/pool
+version=/precise/main/r/rethinkdb/rethinkdb_2.1.2~0precise_amd64.deb
 if [[ ! -f /root/rdb.deb ]]; then
   curl $base/$version > /root/rdb.deb
   dpkg -i /root/rdb.deb

--- a/rdb/src/rdb/core.clj
+++ b/rdb/src/rdb/core.clj
@@ -1,0 +1,130 @@
+(ns rdb.core
+  (:require [clojure [pprint :refer :all]
+                     [string :as str]]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen [core      :as jepsen]
+                    [db        :as db]
+                    [util      :as util :refer [meh timeout]]
+                    [control   :as c :refer [|]]
+                    [client    :as client]
+                    [checker   :as checker]
+                    [model     :as model]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]
+                    [store     :as store]
+                    [report    :as report]
+                    [tests     :as tests]]
+            [jepsen.control [net :as net]
+                            [util :as net/util]]
+            [jepsen.os.debian :as debian]
+            [jepsen.checker.timeline :as timeline]
+            [rethinkdb.core :refer [connect close]]
+            [rethinkdb.query :as r]
+            [knossos.core :as knossos]
+            [cheshire.core :as json])
+  (:import (clojure.lang ExceptionInfo)))
+
+(defn copy-from-home [file]
+    (c/scp* (str (System/getProperty "user.home") "/" file) "/root"))
+
+(defn db []
+  "Rethinkdb (ignores version)."
+  (reify db/DB
+
+    (setup! [_ test node]
+      (debian/install [:libprotobuf7 :libicu48 :psmisc])
+      (let [file "rethinkdb/build/debug/rethinkdb"]
+        (info node (str "Copying ~/" file "..."))
+        (copy-from-home file)
+        (info node (str "Copying ~/" file " DONE!")))
+      (info node "Starting...")
+      ;; TODO: detect server failing to start.
+      (c/ssh* {:cmd "killall rethinkdb bash"})
+      (c/ssh* {:cmd "
+rm -rf /root/rethinkdb_data
+chmod a+x /root/rethinkdb
+nohup /root/rethinkdb \\
+  --bind all \\
+  -n `hostname` \\
+  -j n1:29015 -j n2:29015 -j n3:29015 -j n4:29015 -j n5:29015 \\
+  >/root/1.out 2>/root/2.out &
+sleep 1 # Wait to make sure we've actually cleared out `1.out` and `2.out`.
+# Wait until we see /^Server ready/ in the log file.
+tail -n+0 -F /root/1.out \\
+  | grep --line-buffered '^Server ready' \\
+  | while read line; do pkill -P $$ tail; exit 0; done
+sleep 1 # You never know.
+"})
+      (info node "Starting DONE!")
+)
+
+    (teardown! [_ test node]
+      (info node "Tearing down db...")
+      (c/ssh* {:cmd "
+killall rethinkdb
+f=0
+# Wait for all rethinkdb instances to go away.
+while [[ \"`ps auxww | grep rethinkdb | grep -v grep`\" ]] && [[ \"$f\" -lt 10 ]]; do
+  sleep 1
+  f=$((f+1))
+done
+# If it takes more than 10 seconds, murder them.
+if [[ \"$f\" -ge 10 ]]; then
+  killall -9 rethinkdb
+fi
+"})
+      (info node "Tearing down db DONE!"))))
+
+(defmacro with-errors
+  "Takes an invocation operation, a set of idempotent operation
+  functions which can be safely assumed to fail without altering the
+  model state, and a body to evaluate. Catches RethinkDB errors and
+  maps them to failure ops matching the invocation."
+  [op idempotent-ops & body]
+  `(let [error-type# (if (~idempotent-ops (:f ~op))
+                       :fail
+                       :info)]
+     (try
+       ;; TODO: catch actual RethinkDB errors here.
+       ~@body
+       ; A server selection error means we never attempted the operation in
+       ; the first place, so we know it didn't take place.
+       (catch Exception e#
+         (assoc ~op :type :fail)))))
+
+(defn std-gen
+  "Takes a client generator and wraps it in a typical schedule and nemesis
+  causing failover."
+  [gen]
+  (gen/phases
+    (->> gen
+         (gen/delay 1)
+         (gen/nemesis
+           (gen/seq (cycle [(gen/sleep 60)
+                            {:type :info :f :stop}
+                            {:type :info :f :start}])))
+         (gen/time-limit 600))
+    ;; Recover
+    (gen/nemesis
+      (gen/once {:type :info :f :stop}))
+    ;; Wait for resumption of normal ops
+    (gen/clients
+      (->> gen
+           (gen/delay 1)
+           (gen/time-limit 30)))))
+
+(defn test-
+  "Constructs a test with the given name prefixed by 'rdb ', merging any
+  given options."
+  [name opts]
+  (merge
+    (assoc tests/noop-test
+           :name      (str "rdb " name)
+           :os        debian/os
+           :db        (db)
+           :model     (model/cas-register)
+           :checker   (checker/compose {:linear checker/linearizable})
+           ;; POINT
+           :nemesis   (nemesis/partition-halves))
+    opts))

--- a/rdb/src/rdb/core.clj
+++ b/rdb/src/rdb/core.clj
@@ -90,8 +90,10 @@ fi
        ~@body
        ; A server selection error means we never attempted the operation in
        ; the first place, so we know it didn't take place.
-       (catch Exception e#
-         (assoc ~op :type :fail)))))
+       (catch clojure.lang.ExceptionInfo e#
+         (condp get (:type (ex-data e#))
+           #{:op-indeterminate :unknown} (assoc ~op :type :info :error (str e#))
+           (assoc ~op :type :fail :error (str e#)))))))
 
 (defn std-gen
   "Takes a client generator and wraps it in a typical schedule and nemesis

--- a/rdb/src/rdb/document_cas.clj
+++ b/rdb/src/rdb/document_cas.clj
@@ -1,0 +1,106 @@
+(ns rdb.document-cas
+  "Compare-and-set against a single document."
+  (:require [clojure [pprint :refer :all]
+                     [string :as str]]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen [core      :as jepsen]
+                    [util      :as util :refer [meh timeout]]
+                    [control   :as c :refer [|]]
+                    [client    :as client]
+                    [checker   :as checker]
+                    [model     :as model]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]
+                    [store     :as store]
+                    [report    :as report]
+                    [tests     :as tests]]
+            [jepsen.control [net :as net]
+                            [util :as net/util]]
+            [jepsen.os.debian :as debian]
+            [jepsen.checker.timeline :as timeline]
+            [rdb.core :refer :all]
+            [rethinkdb.core :refer [connect close]]
+            [rethinkdb.query :as r]
+            [knossos.core :as knossos]
+            [cheshire.core :as json])
+  (:import (clojure.lang ExceptionInfo)))
+
+;; TODO: soft durability as an option.
+(defrecord Client [db tbl id primary write_acks use_outdated]
+  client/Client
+  (setup! [this test node]
+    (info node "Connecting CAS Client...")
+    (info node (str `(connect :host ~(name node) :port 28015)))
+    (let [conn (connect :host (name node) :port 28015)]
+      (info node "Connecting CAS Client DONE!")
+      (if (= node :n1)
+        (do
+          (info node "Creating table...")
+          (r/run (r/db-create db) conn)
+          (r/run (r/table-create (r/db db) tbl {:replicas 5}) conn)
+          (r/run (r/insert (r/table (r/db db) tbl) {:id id :val nil}) conn)
+          (pr (r/run
+                (r/update
+                 (r/table (r/db "rethinkdb") "table_config")
+                 {:write_acks write_acks
+                  :shards [{:primary_replica primary
+                            :replicas ["n1" "n2" "n3" "n4" "n5"]}]})
+                conn))
+          (r/run
+            (rethinkdb.query-builder/term :WAIT [(r/table (r/db db) tbl)] {})
+            conn)
+          (info node "Creating table DONE!"))
+        (info node "Not creating table."))
+      (assoc this :conn conn :node node)))
+
+  (invoke! [this test op]
+    (let [fail (if (= :read (:f op)) :fail :info)
+          row (r/get
+               (rethinkdb.query-builder/term
+                :TABLE
+                [(r/db db) tbl]
+                {:use_outdated use_outdated})
+               id)]
+      (with-errors op #{:read}
+       (case (:f op)
+         :read (assoc
+                op
+                :type :ok
+                :value (r/run (r/get-field row "val") (:conn this)))
+         :write (do (r/run
+                      (r/update row {:val (:value op)})
+                      (:conn this))
+                    (assoc op :type :ok))
+         :cas (let [[value value'] (:value op)
+                    res (r/run
+                          (r/update
+                           row
+                           (r/fn [row]
+                             (r/branch
+                              (r/eq (r/get-field row "val") value)
+                              {:val value'}
+                              (r/error "abort"))))
+                          (:conn this))]
+                (assoc op :type (if (= (:errors res) 0) :ok :fail)))))))
+
+  (teardown! [this test]
+    (r/run (r/db-drop db) (:conn this))
+    (close (:conn this))))
+
+(defn client
+  "A client which implements a register on top of an entire document."
+  [write_acks use_outdated]
+  (Client. "jepsen" "cas" 0 "n5" write_acks use_outdated))
+
+; Generators
+(defn w   [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
+(defn r   [_ _] {:type :invoke, :f :read})
+(defn cas [_ _] {:type :invoke, :f :cas, :value [(rand-int 5) (rand-int 5)]})
+
+(defn safe-test
+  "Document-level compare and set with safe settings."
+  []
+  (test- "document {:write_acks 'majority' :use_outdated false}"
+         {:client (client "majority" false)
+          :generator (std-gen (gen/mix [r w cas cas]))}))

--- a/rdb/test/rdb/core_test.clj
+++ b/rdb/test/rdb/core_test.clj
@@ -1,0 +1,26 @@
+(ns rdb.core-test
+  (:require [clojure.test :refer :all]
+            [clojure.pprint :refer :all]
+            [clojure.java.io :as io]
+            [rdb [core :as m]
+                 [document-cas :as dc]]
+            [jepsen [core      :as jepsen]
+                    [util      :as util]
+                    [checker   :as checker]
+                    [model     :as model]
+                    [tests     :as tests]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]
+                    [store     :as store]
+                    [report    :as report]]))
+
+(defn run!
+  [test]
+  (let [test (jepsen/run! test)]
+    (is (:valid? (:results test)))
+    (report/to "report/history.edn"
+               (pprint (:history test)))
+    (report/to "report/linearizability.txt"
+               (-> test :results :linear report/linearizability))))
+
+(deftest document-safe-test (run! (dc/safe-test)))


### PR DESCRIPTION
Requires the version of `clj-rethinkdb` at https://github.com/mlucy/clj-rethinkdb/tree/mlucy_error_types .