### PR TITLE
Enable password-based login for root (used by jsch)

### DIFF
--- a/doc/lxc.md
+++ b/doc/lxc.md
@@ -64,6 +64,12 @@ chmod 600 ~/.ssh/authorized_keys
 vim ~/.ssh/authorized_keys
 ```
 
+Enable password-based login for root (used by jsch):
+```sh
+sed  -i 's,^PermitRootLogin .*,PermitRootLogin yes,g' /etc/ssh/sshd_config
+systemctl restart sshd
+```
+
 Shut each one down with `poweroff` so we can set up the network.
 
 Drop entries in `~/.ssh/config` for nodes:


### PR DESCRIPTION
Maybe I got this wrong and jsch is supposed to use key-based auth, but even after changing the code like this, `lein test` does not work until I enable password-based auth for root:

```patch
diff --git i/jepsen/src/jepsen/control.clj w/jepsen/src/jepsen/control.clj
index 2296ad6..16b01c0 100644
--- i/jepsen/src/jepsen/control.clj
+++ w/jepsen/src/jepsen/control.clj
@@ -15,7 +15,7 @@
 (def ^:dynamic *username* "Username"                      "root")
 (def ^:dynamic *password* "Password (for login and sudo)" "root")
 (def ^:dynamic *port*     "SSH listening port"            22)
-(def ^:dynamic *private-key-path*         "SSH identity file"     nil)
+(def ^:dynamic *private-key-path*         "SSH identity file"     "/home/michael/.ssh/jepsen")
 (def ^:dynamic *strict-host-key-checking* "Verify SSH host keys"  :yes)
 
 (defrecord Literal [string])
```