### PR TITLE
Add SmartOS support and example project

### DIFF
--- a/jepsen/src/jepsen/net.clj
+++ b/jepsen/src/jepsen/net.clj
@@ -23,3 +23,12 @@
       (on-many (:nodes test) (su
                                (exec :iptables :-F :-w)
                                (exec :iptables :-X :-w))))))
+
+(def ipfilter
+  "IPFilter rules"
+  (reify Net
+    (drop! [net test src dest]
+      (on dest (su (exec :echo :block :in :from src :to :any | :ipf :-f :-))))
+    (heal! [net test]
+      (on-many (:nodes test) (su
+                              (exec :ipf :-Fa))))))

--- a/jepsen/src/jepsen/os/smartos.clj
+++ b/jepsen/src/jepsen/os/smartos.clj
@@ -1,0 +1,132 @@
+(ns jepsen.os.smartos
+  "Common tasks for SmartOS boxes."
+  (:use clojure.tools.logging)
+  (:require [clojure.set :as set]
+            [jepsen.util :refer [meh]]
+            [jepsen.os :as os]
+            [jepsen.control :as c]
+            [jepsen.control.util :as cu]
+            [jepsen.control.net :as net]
+            [clojure.string :as str]))
+
+(defn setup-hostfile!
+  "Makes sure the hostfile has a loopback entry for the local hostname"
+  []
+  (let [name    (c/exec :hostname)
+        hosts   (c/exec :cat "/etc/hosts")
+        hosts'  (->> hosts
+                     str/split-lines
+                     (map (fn [line]
+                            (if (and (re-find #"^127\.0\.0\.1\t" line)
+                                     (not (re-find (re-pattern name) line)))
+                              (str line " " name)
+                              line)))
+                     (str/join "\n"))]
+    (c/su (c/exec :echo hosts' :> "/etc/hosts"))))
+
+(defn time-since-last-update
+  "When did we last run a pkgin update, in seconds ago"
+  []
+  (- (Long/parseLong (c/exec :date "+%s"))
+     (Long/parseLong (c/exec :stat :-c "%Y" "/var/db/pkgin/sql.log"))))
+
+(defn update!
+  "Pkgin update."
+  []
+  (c/su (c/exec :pkgin :update)))
+
+(defn maybe-update!
+  "Pkgin update if we haven't done so recently."
+  []
+  (try (when (< 86400 (time-since-last-update))
+         (update!))
+       (catch Exception e
+         (update!))))
+
+(defn installed
+  "Given a list of pkgin packages (strings, symbols, keywords, etc), returns
+  the set of packages which are installed, as strings."
+  [pkgs]
+  (let [pkgs (->> pkgs (map name) set)]
+    (->> (c/exec :pkgin :-p :list)
+         str/split-lines
+         (map (comp first #(str/split %1 #";")))
+         (map (comp second (partial re-find #"(.*)-[^\-]+")))
+         set
+         (#(filter %1 pkgs))
+         set)))
+
+(defn uninstall!
+  "Removes a package or packages."
+  [pkg-or-pkgs]
+  (let [pkgs (if (coll? pkg-or-pkgs) pkg-or-pkgs (list pkg-or-pkgs))
+        pkgs (installed pkgs)]
+    (c/su (apply c/exec :pkgin :-y :remove pkgs))))
+
+(defn installed?
+  "Are the given packages, or singular package, installed on the current
+  system?"
+  [pkg-or-pkgs]
+  (let [pkgs (if (coll? pkg-or-pkgs) pkg-or-pkgs (list pkg-or-pkgs))]
+    (every? (installed pkgs) (map name pkgs))))
+
+(defn installed-version
+  "Given a package name, determines the installed version of that package, or
+  nil if it is not installed."
+  [pkg]
+  (some->> (c/exec :pkgin :-p :list)
+           str/split-lines
+           (map (comp first #(str/split %1 #";")))
+           (map (partial re-find #"(.*)-[^\-]+"))
+           (filter #(= (second %) (name pkg)))
+           first
+           first
+           (re-find #".*-([^\-]+)")
+           second))
+
+(defn install
+  "Ensure the given packages are installed. Can take a flat collection of
+  packages, passed as symbols, strings, or keywords, or, alternatively, a map
+  of packages to version strings."
+  [pkgs]
+  (if (map? pkgs)
+                                        ; Install specific versions
+    (dorun
+     (for [[pkg version] pkgs]
+       (when (not= version (installed-version pkg))
+         (info "Installing" pkg version)
+         (c/exec :pkgin :-y :install 
+                 (str (name pkg) "-" version)))))
+
+                                        ; Install any version
+    (let [pkgs    (set (map name pkgs))
+          missing (set/difference pkgs (installed pkgs))]
+      (when-not (empty? missing)
+        (c/su
+         (info "Installing" missing)
+         (apply c/exec :pkgin :-y :install missing))))))
+
+(def os
+  (reify os/OS
+    (setup! [_ test node]
+      (info node "setting up smartos")
+
+      (setup-hostfile!)
+
+      (maybe-update!)
+
+      (c/su
+        ; Packages!
+        (install [:wget
+                  :curl
+                  :vim
+                  :unzip
+                  :rsyslog
+                  :logrotate]))
+
+      (c/su
+       (c/exec :svcadm :enable :-r :ipfilter))
+
+      (meh (net/heal)))
+
+    (teardown! [_ test node])))

--- a/mongodb-smartos/.gitignore
+++ b/mongodb-smartos/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/mongodb-smartos/LICENSE
+++ b/mongodb-smartos/LICENSE
@@ -1,0 +1,214 @@
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and
+documentation distributed under this Agreement, and
+
+b) in the case of each subsequent Contributor:
+
+i) changes to the Program, and
+
+ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from
+a Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license
+agreement, and (ii) are not derivative works of the Program.
+
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+distribute and sublicense the Contribution of such Contributor, if any, and
+such derivative works, in source code and object code form.
+
+b) Subject to the terms of this Agreement, each Contributor hereby grants
+Recipient a non-exclusive, worldwide, royalty-free patent license under
+Licensed Patents to make, use, sell, offer to sell, import and otherwise
+transfer the Contribution of such Contributor, if any, in source code and
+object code form.  This patent license shall apply to the combination of the
+Contribution and the Program if, at the time the Contribution is added by the
+Contributor, such addition of the Contribution causes such combination to be
+covered by the Licensed Patents. The patent license shall not apply to any
+other combinations which include the Contribution. No hardware per se is
+licensed hereunder.
+
+c) Recipient understands that although each Contributor grants the licenses
+to its Contributions set forth herein, no assurances are provided by any
+Contributor that the Program does not infringe the patent or other
+intellectual property rights of any other entity. Each Contributor disclaims
+any liability to Recipient for claims brought by any other entity based on
+infringement of intellectual property rights or otherwise. As a condition to
+exercising the rights and licenses granted hereunder, each Recipient hereby
+assumes sole responsibility to secure any other intellectual property rights
+needed, if any. For example, if a third party patent license is required to
+allow Recipient to distribute the Program, it is Recipient's responsibility
+to acquire that license before distributing the Program.
+
+d) Each Contributor represents that to its knowledge it has sufficient
+copyright rights in its Contribution, if any, to grant the copyright license
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+
+b) its license agreement:
+
+i) effectively disclaims on behalf of all Contributors all warranties and
+conditions, express and implied, including warranties or conditions of title
+and non-infringement, and implied warranties or conditions of merchantability
+and fitness for a particular purpose;
+
+ii) effectively excludes on behalf of all Contributors all liability for
+damages, including direct, indirect, special, incidental and consequential
+damages, such as lost profits;
+
+iii) states that any provisions which differ from this Agreement are offered
+by that Contributor alone and not by any other party; and
+
+iv) states that source code for the Program is available from such
+Contributor, and informs licensees how to obtain it in a reasonable manner on
+or through a medium customarily used for software exchange.
+
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+
+b) a copy of this Agreement must be included with each copy of the Program.
+
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a
+manner which does not create potential liability for other Contributors.
+Therefore, if a Contributor includes the Program in a commercial product
+offering, such Contributor ("Commercial Contributor") hereby agrees to defend
+and indemnify every other Contributor ("Indemnified Contributor") against any
+losses, damages and costs (collectively "Losses") arising from claims,
+lawsuits and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program in
+a commercial product offering.  The obligations in this section do not apply
+to any claims or Losses relating to any actual or alleged intellectual
+property infringement. In order to qualify, an Indemnified Contributor must:
+a) promptly notify the Commercial Contributor in writing of such claim, and
+b) allow the Commercial Contributor tocontrol, and cooperate with the
+Commercial Contributor in, the defense and any related settlement
+negotiations. The Indemnified Contributor may participate in any such claim
+at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON
+AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER
+EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR
+CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all risks
+associated with its exercise of rights under this Agreement , including but
+not limited to the risks and costs of program errors, compliance with
+applicable laws, damage to or loss of data, programs or equipment, and
+unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and
+does not cure such failure in a reasonable period of time after becoming
+aware of such noncompliance. If all Recipient's rights under this Agreement
+terminate, Recipient agrees to cease use and distribution of the Program as
+soon as reasonably practicable. However, Recipient's obligations under this
+Agreement and any licenses granted by Recipient relating to the Program shall
+continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of
+the Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this
+Agreement, whether expressly, by implication, estoppel or otherwise. All
+rights in the Program not expressly granted under this Agreement are
+reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.

--- a/mongodb-smartos/README.md
+++ b/mongodb-smartos/README.md
@@ -1,0 +1,14 @@
+# mongodb-smartos
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2015 FIXME
+
+Distributed under the Eclipse Public License either version 1.0 or (at
+your option) any later version.

--- a/mongodb-smartos/project.clj
+++ b/mongodb-smartos/project.clj
@@ -1,0 +1,9 @@
+(defproject jepsen.mongodb-smartos "0.1.1"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [jepsen "0.0.7-SNAPSHOT"]
+                 [cheshire "5.4.0"]
+                 [com.novemberain/monger "2.0.0"]])

--- a/mongodb-smartos/resources/mongod.conf
+++ b/mongodb-smartos/resources/mongod.conf
@@ -1,0 +1,81 @@
+# mongod.conf
+
+# Where to store the data.
+
+# Note: if you run mongodb as a non-root user (recommended) you may
+# need to create and set permissions for this directory manually,
+# e.g., if the parent directory isn't mutable by the mongodb user.
+dbpath=/var/lib/mongodb
+
+#where to log
+logpath=/var/log/mongodb/mongod.log
+
+logappend=true
+
+#port = 27017
+
+# Listen to local interface only. Comment out to listen on all interfaces. 
+#bind_ip = 127.0.0.1
+
+# Disables write-ahead journaling
+# nojournal = true
+
+# Enables periodic logging of CPU utilization and I/O wait
+#cpu = true
+
+# Turn on/off security.  Off is currently the default
+#noauth = true
+#auth = true
+
+# Verbose logging output.
+#verbose = true
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+#objcheck = true
+
+# Enable db quota management
+#quota = true
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+#diaglog = 0
+
+# Ignore query hints
+#nohints = true
+
+# Enable the HTTP interface (Defaults to port 28017).
+#httpinterface = true
+
+# Turns off server-side scripting.  This will result in greatly limited
+# functionality
+#noscripting = true
+
+# Turns off table scans.  Any query that would do a table scan fails.
+#notablescan = true
+
+# Disable data file preallocation. We nuke the entire database between runs so
+# this improves startup speed.
+noprealloc = true
+
+# Reduce journal size from 1G to 128M
+smallfiles = true
+
+# Specify .ns file size for new databases.
+# nssize = <size>
+
+# Replication Options
+
+# in replicated mongo databases, specify the replica set name here
+replSet=jepsen
+# maximum size in megabytes for replication operation log
+#oplogSize=1024
+# path to a key file storing authentication info for connections
+# between replica set members
+#keyFile=/path/to/keyfile
+#
+#

--- a/mongodb-smartos/src/jepsen/mongodb_smartos/core.clj
+++ b/mongodb-smartos/src/jepsen/mongodb_smartos/core.clj
@@ -1,0 +1,393 @@
+(ns jepsen.mongodb-smartos.core
+  (:require [clojure [pprint :refer :all]
+                     [string :as str]]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen [core      :as jepsen]
+                    [db        :as db]
+                    [util      :as util :refer [meh timeout]]
+                    [control   :as c :refer [|]]
+                    [client    :as client]
+                    [checker   :as checker]
+                    [model     :as model]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]
+                    [store     :as store]
+                    [report    :as report]
+                    [net]
+                    [tests     :as tests]]
+            [jepsen.control [net :as net]
+                            [util :as net/util]]
+            [jepsen.os.smartos :as smartos]
+            [jepsen.checker.timeline :as timeline]
+            [knossos.core :as knossos]
+            [cheshire.core :as json]
+            [monger.core :as mongo]
+            [monger.collection :as mc]
+            [monger.result :as mr]
+            [monger.query :as mq]
+            [monger.command :as command]
+            [monger.operators :refer :all]
+            [monger.conversion :refer [from-db-object]])
+  (:import (clojure.lang ExceptionInfo)
+           (org.bson BasicBSONObject
+                     BasicBSONDecoder)
+           (org.bson.types ObjectId)
+           (com.mongodb DB
+                        WriteConcern
+                        ReadPreference)))
+
+(defn install!
+  "Installs the given version of MongoDB."
+  [node db-version tools-version]
+  (c/su
+   (smartos/install {:mongodb db-version
+                     :mongo-tools tools-version})
+   (c/exec :mkdir :-p "/var/lib/mongodb")
+   (c/exec :chown :-R "mongodb:mongodb" "/var/lib/mongodb")))
+
+(defn configure!
+  "Deploy configuration files to the node."
+  [node]
+  (c/exec :echo (-> "mongod.conf" io/resource slurp)
+          :> "/opt/local/etc/mongod.conf"))
+
+(defn start!
+  "Starts Mongod"
+  [node]
+  (info node "starting mongod")
+  (c/su
+   (meh (c/exec :svcadm :clear :mongodb))
+   (c/exec :svcadm :enable :-r :mongodb)))
+
+(defn stop!
+  "Stops Mongod"
+  [node]
+  (info node "stopping mongod")
+  (c/su
+    (timeout 5000 nil
+             (meh (c/exec :svcadm :disable :mongodb)))
+    (meh (c/exec :pkill :-9 :mongod))))
+
+(defn wipe!
+  "Shuts down MongoDB and wipes data."
+  [node]
+  (stop! node)
+  (info node "deleting data files")
+  (c/su
+    (c/exec :rm :-rf (c/lit "/var/log/mongodb/*"))
+    (c/exec :rm :-rf (c/lit "/var/lib/mongodb/*"))))
+
+(defn uninstall!
+  "Uninstalls the current version of mongodb"
+  [node]
+  (info node "uninstalling mongodb")
+  (smartos/uninstall! ["mongo" "mongo-tools"]))
+
+(defn mongo!
+  "Run a Mongo shell command. Spits back an unparsable kinda-json string,
+  because go fuck yourself, that's why."
+  [cmd]
+  (-> (c/exec :mongo :--quiet :--eval (str "printjson(" cmd ")"))))
+
+(defn parse-result
+  "Takes a Mongo result and returns it as a Clojure data structure (using
+  mongo.result/from-db-object), unless it contains an error, in which case an
+  ex-info exception of :type :mongo is raised."
+  [res]
+  (if (mr/ok? res)
+    (from-db-object res true)
+    (throw (ex-info (str "Mongo error: "
+                         (get res "errmsg")
+                         " - "
+                         (get res "info"))
+                    {:type   :mongo
+                     :result res}))))
+
+(defn command!
+  "Wrapper for monger's admin command API where the command
+  is the first key in the (ordered!?) map."
+  [conn db-name & cmd]
+;  (info "command" (seq (.getServerAddressList conn)) db-name cmd)
+  (timeout 10000 (throw (ex-info "timeout" {:db-name db-name :cmd cmd}))
+           (-> conn
+               (mongo/get-db db-name)
+               (mongo/command (apply array-map cmd))
+               parse-result)))
+
+(defn admin-command!
+  "Runs a command on the admin database."
+  [conn & args]
+  (apply command! conn "admin" args))
+
+(defn replica-set-status
+  "Returns the current replica set status."
+  [conn]
+  (admin-command! conn :replSetGetStatus 1))
+
+(defn replica-set-initiate!
+  "Initialize a replica set on a node."
+  [conn config]
+  (try
+    (admin-command! conn :replSetInitiate config)
+    (catch ExceptionInfo e
+      (condp re-find (get-in (ex-data e) [:result "errmsg"])
+        ; Some of the time (but not all the time; why?) Mongo returns this error
+        ; from replsetinitiate, which is, as far as I can tell, not actually an
+        ; error (?)
+        #"Received replSetInitiate - should come online shortly"
+        nil
+
+        ; This is a hint we should back off and retry; one of the nodes probably
+        ; isn't fully alive yet.
+        #"need all members up to initiate, not ok"
+        (do (info "not all members alive yet; retrying replica set initiate"
+            (Thread/sleep 1000)
+            (replica-set-initiate! conn config)))
+
+        ; Or by default re-throw
+        (throw e)))))
+
+(defn replica-set-master?
+  "What's this node's replset role?"
+  [conn]
+  (admin-command! conn :isMaster 1))
+
+(defn replica-set-config
+  "Returns the current replset config."
+  [conn]
+  (-> conn
+      (mongo/get-db "local")
+      (mc/find-one "system.replset" {})
+      (from-db-object true)))
+
+(defn replica-set-reconfigure!
+  "Apply new configuration for a replica set."
+  [conn conf]
+  (admin-command! conn :replSetReconfig conf))
+
+(defn node+port->node
+  "Take a mongo \"n1:27107\" string and return just the node as a keyword:
+  :n1."
+  [s]
+  (keyword ((re-find #"(\w+?):" s) 1)))
+
+(defn primaries
+  "What nodes does this conn think are primaries?"
+  [conn]
+  (->> (replica-set-status conn)
+       :members
+       (filter #(= "PRIMARY" (:stateStr %)))
+       (map :name)
+       (map node+port->node)))
+
+(defn primary
+  "Which single node does this conn think the primary is? Throws for multiple
+  primaries, cuz that sounds like a fun and interesting bug, haha."
+  [conn]
+  (let [ps (primaries conn)]
+    (when (< 1 (count ps))
+      (throw (IllegalStateException.
+               (str "Multiple primaries known to "
+                    conn
+                    ": "
+                    ps))))
+
+    (first ps)))
+
+(def mongo-conn-opts
+  "Connection options for Mongo."
+  (mongo/mongo-options
+    {:max-wait-time   20000
+     :connect-timeout 5000
+     :socket-timeout  10000})) ; a buncha simple ops in mongo take 1000+ ms (!?)
+
+(defn await-conn
+  "Block until we can connect to the given node. Returns a connection to the
+  node."
+  [node]
+  (timeout (* 100 1000)
+           (throw (ex-info "Timed out trying to connect to MongoDB"
+                           {:node node}))
+           (loop []
+             (or (try
+                   (let [conn (mongo/connect (mongo/server-address (name node))
+                                             mongo-conn-opts)]
+                     (try
+                       (command/top conn)
+                       conn
+                       (catch Throwable t
+                         (mongo/disconnect conn)
+                         (throw t))))
+                   (catch com.mongodb.MongoServerSelectionException e
+                     nil))
+                 (do
+                   (Thread/sleep 1000)
+                   (recur))))))
+
+(defn await-primary
+  "Block until a primary is known to the current node."
+  [conn]
+  (while (not (primary conn))
+    (Thread/sleep 1000)))
+
+(defn await-join
+  "Block until all nodes in the test are known to this connection's replset
+  status"
+  [test conn]
+  (while (try (not= (set (:nodes test))
+                    (->> (replica-set-status conn)
+                         :members
+                         (map :name)
+                         (map node+port->node)
+                         set))
+              (catch ExceptionInfo e
+                (if (re-find #"should come online shortly"
+                             (get-in (ex-data e) [:result "errmsg"]))
+                  true
+                  (throw e))))
+    (Thread/sleep 1000)))
+
+(defn target-replica-set-config
+  "Generates the config for a replset in a given test."
+  [test]
+  {:_id "jepsen"
+   :members (->> test
+                 :nodes
+                 (map-indexed (fn [i node]
+                                {:_id  i
+                                 :host (str (name node) ":27017")})))})
+
+(defn join!
+  "Join nodes into a replica set. Blocks until any primary is visible to all
+  nodes which isn't really what we want but oh well."
+  [node test]
+  ; Gotta have all nodes online for this
+  (jepsen/synchronize test)
+  (Thread/sleep 10000)
+
+  ; Initiate RS
+  (when (= node (jepsen/primary test))
+    (with-open [conn (await-conn node)]
+      (info node "Initiating replica set")
+      (replica-set-initiate! conn (target-replica-set-config test))
+
+      (info node "Jepsen primary waiting for cluster join")
+      (await-join test conn)
+      (info node "Jepsen primary waiting for mongo election")
+      (await-primary conn)
+      (info node "Primary ready.")))
+
+  ; For reasons I really don't understand, you have to prevent other nodes
+  ; from checking the replset status until *after* we initiate the replset on
+  ; the primary--so we insert a barrier here to make sure other nodes don't
+  ; wait until primary initiation is complete.
+  (jepsen/synchronize test)
+
+  ; For other reasons I don't understand, you *have* to open a new set of
+  ; connections after replset initation. I have a hunch that this happens
+  ; because of a deadlock or something in mongodb itself, but it could also
+  ; be a client connection-closing-detection bug.
+
+  ; Amusingly, we can't just time out these operations; the client appears to
+  ; swallow thread interrupts and keep on doing, well, something. FML.
+  (with-open [conn (await-conn node)]
+    (info node "waiting for cluster join")
+    (await-join test conn)
+
+    (info node "waiting for primary")
+    (await-primary conn)
+
+    (info node "primary is" (primary conn))
+    (jepsen/synchronize test)))
+
+(defn db
+  "MongoDB for a particular version."
+  [db-version tools-version]
+  (reify db/DB
+    (setup! [_ test node]
+      (doto node
+        (install! db-version tools-version)
+        (configure!)
+        (start!)
+        (join! test)))
+
+    (teardown! [_ test node]
+      (wipe! node))))
+
+(defn cluster-client
+  "Returns a mongoDB connection for all nodes in a test."
+  [test]
+  (mongo/connect (->> test :nodes (map name) (mapv mongo/server-address))
+                 mongo-conn-opts))
+
+(defn upsert
+  "Ensures the existence of the given document."
+  [db coll doc write-concern]
+  (assert (:_id doc))
+  (mc/upsert db coll
+             {:_id (:_id doc)}
+             doc
+             {:write-concern write-concern}))
+
+(defmacro with-errors
+  "Takes an invocation operation, a set of idempotent operation functions which
+  can be safely assumed to fail without altering the model state, and a body to
+  evaluate. Catches MongoDB errors and maps them to failure ops matching the
+  invocation."
+  [op idempotent-ops & body]
+  `(let [error-type# (if (~idempotent-ops (:f ~op))
+                       :fail
+                       :info)]
+     (try
+       ~@body
+       ; A server selection error means we never attempted the operation in
+       ; the first place, so we know it didn't take place.
+       (catch com.mongodb.MongoServerSelectionException e#
+         (assoc ~op :type :fail :error :no-server))
+
+       ; Command failures also did not take place.
+       (catch com.mongodb.CommandFailureException e#
+         (if (= "not master" (.. e# getCommandResult getErrorMessage))
+           (assoc ~op :type :fail :error :not-master)
+           (throw e#)))
+
+       ; A network error is indeterminate
+       (catch com.mongodb.MongoException$Network e#
+         (assoc ~op :type error-type# :error :network-error)))))
+
+(defn std-gen
+  "Takes a client generator and wraps it in a typical schedule and nemesis
+  causing failover."
+  [gen]
+  (gen/phases
+    (->> gen
+         (gen/delay 1)
+         (gen/nemesis
+           (gen/seq (cycle [(gen/sleep 60)
+                            {:type :info :f :stop}
+                            {:type :info :f :start}])))
+         (gen/time-limit 600))
+    ; Recover
+    (gen/nemesis
+      (gen/once {:type :info :f :stop}))
+    ; Wait for resumption of normal ops
+    (gen/clients
+      (->> gen
+           (gen/delay 1)
+           (gen/time-limit 30)))))
+
+(defn test-
+  "Constructs a test with the given name prefixed by 'mongodb ', merging any
+  given options."
+  [name opts]
+  (merge
+    (assoc tests/noop-test
+           :name      (str "mongodb " name)
+           :os        smartos/os
+           :net       jepsen.net/ipfilter
+           :db        (db "3.0.4" "3.0.6")
+           :model     (model/cas-register)
+           :checker   (checker/compose {:linear checker/linearizable})
+           :nemesis   (nemesis/partition-random-halves))
+    opts))

--- a/mongodb-smartos/src/jepsen/mongodb_smartos/document_cas.clj
+++ b/mongodb-smartos/src/jepsen/mongodb_smartos/document_cas.clj
@@ -1,0 +1,114 @@
+(ns jepsen.mongodb-smartos.document-cas
+  "Compare-and-set against a single document."
+  (:require [clojure [pprint :refer :all]
+                     [string :as str]]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen [core      :as jepsen]
+                    [util      :as util :refer [meh timeout]]
+                    [control   :as c :refer [|]]
+                    [client    :as client]
+                    [checker   :as checker]
+                    [model     :as model]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]
+                    [store     :as store]
+                    [report    :as report]
+                    [tests     :as tests]]
+            [jepsen.control [net :as net]
+                            [util :as net/util]]
+            [jepsen.os.debian :as debian]
+            [jepsen.checker.timeline :as timeline]
+            [knossos.core :as knossos]
+            [cheshire.core :as json]
+            [jepsen.mongodb-smartos.core :refer :all]
+            [monger.core :as mongo]
+            [monger.collection :as mc]
+            [monger.result :as mr]
+            [monger.query :as mq]
+            [monger.command]
+            [monger.operators :refer :all]
+            [monger.conversion :refer [from-db-object]])
+  (:import (clojure.lang ExceptionInfo)
+           (org.bson BasicBSONObject
+                     BasicBSONDecoder)
+           (org.bson.types ObjectId)
+           (com.mongodb DB
+                        WriteConcern
+                        ReadPreference)))
+
+(defrecord Client [db-name coll id write-concern conn db]
+  client/Client
+  (setup! [this test node]
+    (let [conn (cluster-client test)
+          db   (mongo/get-db conn db-name)]
+      ; Create document
+      (upsert db coll {:_id id, :value nil} write-concern)
+
+      (assoc this :conn conn, :db db)))
+
+  (invoke! [this test op]
+    ; Reads are idempotent; we can treat their failure as an info.
+    (with-errors op #{:read}
+      (case (:f op)
+        ; :read (let [res (mc/find-map-by-id db coll id)]
+        :read (let [res (->> (mq/with-collection db coll
+                               (mq/find {:_id id})
+                               (mq/fields [:_id :value])
+                               (mq/read-preference (ReadPreference/primary)))
+                             first)]
+                (assoc op :type :ok, :value (:value res)))
+
+        :write (let [res (parse-result
+                           (mc/update-by-id db coll id
+                                            {:_id id, :value (:value op)}
+                                            {:write-concern write-concern}))]
+                 (assert (= 1 (.getN res)))
+                 (assoc op :type :ok))
+
+        :cas   (let [[value value'] (:value op)
+                     res (parse-result
+                           (mc/update db coll
+                                      {:_id id, :value value}
+                                      {:_id id, :value value'}
+                                      {:write-concern write-concern}))]
+                 ; Check how many documents we actually modified...
+                 (condp = (.getN res)
+                   0 (assoc op :type :fail)
+                   1 (assoc op :type :ok)
+                   2 (throw (ex-info "CAS unexpected number of modified docs"
+                                     {:n (.getN res)
+                                      :res res})))))))
+
+  (teardown! [_ test]
+    (mongo/disconnect conn)))
+
+(defn client
+  "A client which implements a register on top of an entire document."
+  [write-concern]
+  (Client. "jepsen"
+           "jepsen"
+           (ObjectId.)
+           write-concern
+           nil
+           nil))
+
+; Generators
+(defn w   [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
+(defn r   [_ _] {:type :invoke, :f :read})
+(defn cas [_ _] {:type :invoke, :f :cas, :value [(rand-int 5) (rand-int 5)]})
+
+(defn majority-test
+  "Document-level compare and set with WriteConcern MAJORITY"
+  []
+  (test- "document cas majority"
+         {:client (client WriteConcern/MAJORITY)
+          :generator (std-gen (gen/mix [r w cas cas]))}))
+
+(defn no-read-majority-test
+  "Document-level compare and set with MAJORITY, excluding reads because mongo
+  doesn't have linearizable reads."
+  []
+  (test- "document cas no-read majority"
+         {:client (client WriteConcern/MAJORITY)
+          :generator (std-gen (gen/mix [w cas cas]))}))

--- a/mongodb-smartos/src/jepsen/mongodb_smartos/transfer.clj
+++ b/mongodb-smartos/src/jepsen/mongodb_smartos/transfer.clj
@@ -1,0 +1,281 @@
+(ns jepsen.mongodb-smartos.transfer
+  "Simulates bank account transfers between N accounts, as per
+  From http://docs.mongodb.org/manual/tutorial/perform-two-phase-commits/"
+  (:refer-clojure :exclude [read])
+  (:require [clojure [pprint :refer :all]
+                     [string :as str]]
+            [clojure.java.io :as io]
+            [clojure.tools.logging :refer [debug info warn]]
+            [jepsen [core      :as jepsen]
+                    [util      :as util :refer [meh timeout]]
+                    [control   :as c :refer [|]]
+                    [client    :as client]
+                    [checker   :as checker]
+                    [model     :as model]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]
+                    [store     :as store]
+                    [report    :as report]
+                    [tests     :as tests]]
+            [jepsen.control [net :as net]
+                            [util :as net/util]]
+            [jepsen.os.debian :as debian]
+            [jepsen.checker.timeline :as timeline]
+            [knossos.core :as knossos]
+            [cheshire.core :as json]
+            [jepsen.mongodb-smartos.core :refer :all]
+            [monger.core :as mongo]
+            [monger.collection :as mc]
+            [monger.result :as mr]
+            [monger.query :as mq]
+            [monger.command]
+            [monger.operators :refer :all]
+            [monger.conversion :refer [from-db-object]])
+  (:import (knossos.core Model)
+           (clojure.lang ExceptionInfo)
+           (org.bson BasicBSONObject
+                     BasicBSONDecoder)
+           (org.bson.types ObjectId)
+           (com.mongodb DB
+                        WriteConcern
+                        ReadPreference)))
+
+(defn p0-create-txn
+  "Creates a new transaction in state PENDING and returns it. txn should be a
+  map with :from, :to, and :amount keys."
+  [db txns write-concern txn]
+  (let [txn (from-db-object
+              (mc/insert-and-return db txns
+                                    {:_id (ObjectId.)
+                                     :state       "pending"
+                                     :from        (:from txn)
+                                     :to          (:to txn)
+                                     :amount      (:amount txn)}
+                                    write-concern)
+              true)]
+    ; jfc mongo error handling is incomprehensibly inconsistent
+    ; - What does insert-and-return return for failure?
+    ; - Why doesn't insert-and-return return something that responds to
+    ;   result/ok? for the successful case?
+    (assert (map? txn))
+    (assert (= #{:_id :state :from :to :amount} (set (keys txn))))
+    txn))
+
+(defn p1-find-txn
+  "Finds a single transaction ID in the INITIAL state."
+  [db txns]
+  (:_id (mc/find-one-as-map db txns {:state "initial"})))
+
+(defn p2-begin-txn
+  "Updates the given transaction from initial to pending. Returns the
+  transaction."
+  [db txns write-concern txn]
+  (parse-result
+    (mc/update db txns
+               {:_id (:_id txn), :state "initial"}
+               {$set           {:state "pending"}
+                "$currentDate" {:lastModified true}}
+               {:write-concern write-concern})
+    txn))
+
+(defn p3-apply-txn
+  "Applies the given transaction to both accounts. Returns the transaction."
+  [db accts write-concern txn]
+  (parse-result
+    (mc/update db accts
+               {:_id (:from txn), :pendingTxns {$ne (:_id txn)}}
+               {$inc  {:balance (- (:amount txn))}
+                $push {:pendingTxns (:_id txn)}}
+               {:write-concern write-concern}))
+  (parse-result
+    (mc/update db accts
+               {:_id (:to txn), :pendingTxns {$ne (:_id txn)}}
+               {$inc  {:balance (:amount txn)}
+                $push {:pendingTxns (:_id txn)}}
+               {:write-concern write-concern}))
+  txn)
+
+(defn p4-applied-txn
+  "Mark the transaction as successfully applied. Returns the transaction."
+  [db txns write-concern txn]
+  (parse-result
+    (mc/update db txns
+               {:_id (:_id txn), :state "pending"}
+               {$set {:state "applied"}
+                "$currentDate" {:lastModified true}}
+               {:write-concern write-concern}))
+  txn)
+
+(defn p5-clear-pending
+  "Clear the given transaction from the relevant account pending txn lists.
+  Returns the transaction."
+  [db accts write-concern txn]
+  (parse-result
+    (mc/update db accts
+               {:_id (:from txn), :pendingTxns (:_id txn)}
+               {$pull {:pendingTxns (:_id txn)}}
+               {:write-concern write-concern}))
+  (parse-result
+    (mc/update db accts
+               {:_id (:to txn), :pendingTxns (:_id txn)}
+               {$pull {:pendingTxns (:_id txn)}}
+               {:write-concern write-concern}))
+  txn)
+
+(defn p6-finish-txn
+  "Marks the transaction as complete."
+  [db txns write-concern id]
+  (parse-result
+    (mc/update db txns
+               {:_id id, :state "applied"}
+               {$set {:state "done"}
+                "$currentDate" {:lastModified true}}
+               {:write-concern write-concern})))
+
+(defrecord Client [db-name txns accts acct-ids starting-balance write-concern conn db]
+  client/Client
+  (setup! [this test node]
+    (let [conn (cluster-client test)
+         db     (mongo/get-db conn db-name)]
+      ; Create accounts
+      (doseq [id acct-ids]
+        (upsert db accts {:_id          id
+                          :balance      starting-balance
+                          :pendingTxns  []}
+                write-concern))
+      (assoc this :conn conn, :db db)))
+
+  (invoke! [this test op]
+    (with-errors op #{:read}
+      (case (:f op)
+        :read (->> (mq/with-collection db accts
+                     (mq/find {})
+                     (mq/fields [:_id :balance])
+                     (mq/read-preference (ReadPreference/primary)))
+                   (map (juxt :_id :balance))
+                   (into {})
+                   (assoc op :type :ok, :value))
+
+        :partial-read (->> (mq/with-collection db accts
+                             (mq/find {:pendingTxns {$size 0}})
+                             (mq/read-preference (ReadPreference/primary)))
+                           (map (juxt :_id :balance))
+                           (into {})
+                           (assoc op :type :ok, :value))
+
+        :transfer (do (->> (:value op)
+                           (p0-create-txn    db txns  write-concern)
+                           (p3-apply-txn     db accts write-concern)
+                           (p4-applied-txn   db txns  write-concern)
+                           (p5-clear-pending db accts write-concern)
+                           (p6-finish-txn    db accts write-concern))
+                      (assoc op :type :ok)))))
+
+  (teardown! [_ test]
+    (mongo/disconnect conn)))
+
+(defn client
+  "A client which transfers balances between a pool of n accounts, each
+  beginning with starting-balance."
+  [n starting-balance write-concern]
+  (Client. "jepsen"
+           "txns"
+           "accts"
+           (vec (range n))
+           starting-balance
+           write-concern
+           nil
+           nil))
+
+(defrecord Accounts [accts]
+  Model
+  (step [m op]
+    (let [value (:value op)]
+      (try
+        (condp = (:f op)
+          :read (if (= accts value)
+                  m
+                  (knossos/inconsistent
+                    (str "Can't read " value " from " accts)))
+
+          :partial-read (if (every? true?
+                                    (for [[acct-id balance] value]
+                                      (= balance (get accts acct-id))))
+                          m
+                          (knossos/inconsistent
+                            (str value " isn't consistent with " accts)))
+
+          :transfer (let [{:keys [from to amount]} value]
+                      (Accounts.
+                        (assoc accts
+                               from (- (get accts from) amount)
+                               to   (+ (get accts to)   amount)))))
+        (catch Throwable t
+          (warn "Account model error:" :accts accts :op op)
+          (throw t))))))
+
+(defn account-model
+  "Given a map of account IDs to balances, models transfers between those
+  accounts."
+  [accts]
+  (Accounts. accts))
+
+; Generators
+(defn read
+  "Reads the current state of all accounts without any synchronization."
+  [_ _]
+  {:type :invoke, :f :read})
+
+(defn partial-read
+  "Reads the state of all accounts without a transaction in progress."
+  [_ _]
+  {:type :invoke, :f :partial-read})
+
+(defn transfer
+  "Transfers a random amount between two randomly selected accounts."
+  [test process]
+  (let [acct-ids (-> test :client :acct-ids)]
+    {:type  :invoke
+     :f     :transfer
+     :value {:from   (rand-nth acct-ids)
+             :to     (rand-nth acct-ids)
+             :amount (rand-int 5)}}))
+
+(def diff-transfer
+  "Like transfer, but only transfers between *different* accounts."
+  (gen/filter (fn [op] (not= (-> op :value :from)
+                             (-> op :value :to)))
+              transfer))
+
+(defn transfer-test
+  "Generic transfer test"
+  [name opts]
+  (let [n                 3
+        starting-balance  10]
+    (test- (str "transfer " name)
+           (merge {:client (client n starting-balance WriteConcern/JOURNAL_SAFE)
+                   :model  (account-model (->> starting-balance
+                                               (repeat n)
+                                               (map-indexed vector)
+                                               (into {})))}
+                  opts))))
+
+; Tests
+(defn basic-read-test
+  "Transfer test with a mix of simple reads and transfers."
+  []
+  (transfer-test "basic read"
+                 {:generator (std-gen (gen/mix [read transfer]))}))
+
+(defn partial-read-test
+  "Reads can only take place on records which don't have any pending
+  transactions."
+  []
+  (transfer-test "partial read"
+                 {:generator (std-gen (gen/mix [partial-read transfer]))}))
+
+(defn diff-account-test
+  "Partial reads and only different-account transfers."
+  []
+  (transfer-test "diff account"
+                 {:generator (std-gen (gen/mix [partial-read diff-transfer]))}))

--- a/mongodb-smartos/test/jepsen/mongodb_smartos/core_test.clj
+++ b/mongodb-smartos/test/jepsen/mongodb_smartos/core_test.clj
@@ -1,0 +1,27 @@
+(ns jepsen.mongodb-smartos.core-test
+  (:require [clojure.test :refer :all]
+            [clojure.pprint :refer :all]
+            [clojure.java.io :as io]
+            [jepsen.mongodb-smartos [core :as m]
+                                    [document-cas :as dc]
+                                    [transfer :as t]]
+            [jepsen [core      :as jepsen]
+                    [util      :as util]
+                    [checker   :as checker]
+                    [model     :as model]
+                    [tests     :as tests]
+                    [generator :as gen]
+                    [nemesis   :as nemesis]
+                    [store     :as store]
+                    [report    :as report]]))
+
+(defn run!
+  [test]
+  (let [test (jepsen/run! test)]
+    (is (:valid? (:results test)))))
+
+(deftest document-cas-majority-test         (run! (dc/majority-test)))
+;(deftest document-cas-no-read-majority-test (run! (dc/no-read-majority-test)))
+;(deftest transfer-basic-read-test           (run! (t/basic-read-test)))
+;(deftest transfer-partial-read-test         (run! (t/partial-read-test)))
+;(deftest transfer-diff-account-test         (run! (t/diff-account-test)))


### PR DESCRIPTION
This PR adds SmartOS support.

In particular, it adds a jepsen.os.smartos namespace that supports the os protocol and adds analogs for the functions in the jepsen.os.debian namespace. It also adds an ipfilter implementation of the net protocol.  Like the iptables implementation, the ipfilter implementation assumes it has complete control of firewalling on that machine.

In order to showcase the use of these namespaces and make testing possible, this PR also includes an adapted version of the mongodb Jepsen tests. These have been successfully run against SmartOS. The tests for the Jepsen project also pass, as expected.

This has been tested against version 15.2.0 of the base-64 SmartOS image.