### PR TITLE
Fix hardcoded node names

### DIFF
--- a/jepsen/test/jepsen/core_test.clj
+++ b/jepsen/test/jepsen/core_test.clj
@@ -1,5 +1,6 @@
 (ns jepsen.core-test
   (:use jepsen.core
+        jepsen.control.net
         clojure.test
         clojure.pprint
         clojure.tools.logging)
@@ -76,12 +77,12 @@
                                slurp
                                str/trim)))))
     (is (= @os-startups @os-teardowns @db-startups @db-teardowns
-           {:n1 "n1"
-            :n2 "n2"
-            :n3 "n3"
-            :n4 "n4"
-            :n5 "n5"}))
-    (is (= @db-primaries ["n1"]))))
+           {:n1 (:n1 hosts-map)
+            :n2 (:n2 hosts-map)
+            :n3 (:n3 hosts-map)
+            :n4 (:n4 hosts-map)
+            :n5 (:n5 hosts-map)}))
+    (is (= @db-primaries [(:n1 hosts-map)]))))
 
 (deftest worker-recovery-test
   ; Workers should only consume n ops even when failing.


### PR DESCRIPTION
W/o this patch, nodes names cannot be changed
at the single place (net.clj)

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>