### PR TITLE
Dockerfile: fix build cache issue

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,16 +7,16 @@ ENV LEIN_ROOT true
 #
 # Jepsen dependencies
 #
-RUN apt-get -y -q install software-properties-common 
-RUN add-apt-repository ppa:openjdk-r/ppa
-RUN apt-get -y -q update
-
-RUN apt-get install -qqy \
-    openjdk-8-jdk \
-    libjna-java \
-    git \
-    gnuplot \
-    wget
+RUN apt-get -y -q update && \
+    apt-get -y -q install software-properties-common && \
+    add-apt-repository ppa:openjdk-r/ppa && \
+    apt-get -y -q update && \
+    apt-get install -qqy \
+        openjdk-8-jdk \
+        libjna-java \
+        git \
+        gnuplot \
+        wget
 
 
 RUN cd / && wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && mv /lein /usr/bin 


### PR DESCRIPTION
`docker build` fails locally due to the cache.
This patch runs `apt-get update` before running `apt-get install software-properties-common` so as to invalidate old apt cache.
