### PR TITLE
Prefix POSIX timestamp with @ when setting time via date command.

### DIFF
--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -131,7 +131,7 @@
 (defn set-time!
   "Set the local node time in POSIX seconds."
   [t]
-  (c/su (c/exec :date "+%s" :-s (long t))))
+  (c/su (c/exec :date "+%s" :-s (str \@ (long t)))))
 
 (defn clock-scrambler
   "Randomizes the system clock of all nodes within a dt-second window."


### PR DESCRIPTION
Currently, the `clock-scrambler` fails to set local time on my (Debian 8.1) jepsen nodes. The failure is something like:

```
root@n1:~# date +%s -s 1446496762
date: invalid date '1446496762'
```

This PR adds an @ prefix to the timestamp to allow the command to succeed.