### PR TITLE
Clock scrambler should properly handle :start and :stop ops

### DIFF
--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -141,9 +141,10 @@
       this)
 
     (invoke! [this test op]
-      (c/on-many (:nodes test)
-                 (set-time! (+ (/ (System/currentTimeMillis) 1000)
-                               (- (rand-int (* 2 dt)) dt)))))
+      (assoc op :value
+                (c/on-many (:nodes test)
+                           (set-time! (+ (/ (System/currentTimeMillis) 1000)
+                                         (- (rand-int (* 2 dt)) dt))))))
 
     (teardown! [this test]
       (c/on-many (:nodes test)


### PR DESCRIPTION
Clock scrambler should properly handle :start and :stop ops by assoc'ing the resulting time as the op :value.

Without this, Nemesis processes presently crash due to the following assertion:

https://github.com/aphyr/jepsen/blob/e6da77648b5d7b35b66555eecaf5331b7104b36e/jepsen/src/jepsen/core.clj#L143