### PR TITLE
Fix the checker throwing exception in analysis

### DIFF
--- a/jepsen/src/jepsen/checker.clj
+++ b/jepsen/src/jepsen/checker.clj
@@ -169,7 +169,9 @@
             ; Unexpected records are those we *never* tried to enqueue. Maybe
             ; leftovers from some earlier state. Definitely don't want your
             ; queue emitting records from nowhere!
-            unexpected (set/difference (core/set dequeues) (core/set attempts))
+            unexpected (try
+                         (set/difference (core/set dequeues) (core/set attempts))
+                         (catch Exception _#))
 
             ; Duplicate records are those which were dequeued more times than
             ; they could have been enqueued; but were attempted at least once.


### PR DESCRIPTION
It seems, the unexpected evaluator behaves in unexpected
way. Ignore exceptions raised to make things go smooth.

Closes: https://github.com/aphyr/jepsen/issues/104

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>