### PR TITLE
Fix missed parameter

### DIFF
--- a/galera/src/jepsen/galera.clj
+++ b/galera/src/jepsen/galera.clj
@@ -338,7 +338,7 @@
   "Balances must all be non-negative and sum to the model's total."
   []
   (reify checker/Checker
-    (check [this test model history]
+    (check [this test model history _]
       (let [bad-reads (->> history
                            (r/filter op/ok?)
                            (r/filter #(= :read (:f %)))

--- a/galera/src/jepsen/galera/dirty_reads.clj
+++ b/galera/src/jepsen/galera/dirty_reads.clj
@@ -75,7 +75,7 @@
   read."
   []
   (reify checker/Checker
-    (check [this test model history]
+    (check [this test model history _]
       (let [failed-writes (->> history
                                (r/filter op/fail?)
                                (r/filter #(= :write (:f %)))

--- a/percona/src/jepsen/percona.clj
+++ b/percona/src/jepsen/percona.clj
@@ -317,7 +317,7 @@
   "Balances must all be non-negative and sum to the model's total."
   []
   (reify checker/Checker
-    (check [this test model history]
+    (check [this test model history _]
       (let [bad-reads (->> history
                            (r/filter op/ok?)
                            (r/filter #(= :read (:f %)))

--- a/percona/src/jepsen/percona/dirty_reads.clj
+++ b/percona/src/jepsen/percona/dirty_reads.clj
@@ -75,7 +75,7 @@
   read."
   []
   (reify checker/Checker
-    (check [this test model history]
+    (check [this test model history _]
       (let [failed-writes (->> history
                                (r/filter op/fail?)
                                (r/filter #(= :write (:f %)))


### PR DESCRIPTION
Use [ this test model history _ ] for Checker reify.
The 'ops' is missing, so the test thorws w/o the fix.
It seems not used though, so masked with "_".

Signed-off-by: Bogdan Dobrelya <bdobrelia@mirantis.com>