### PR TITLE
Fixes for jepson.nemesis/compose

### DIFF
--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -162,7 +162,7 @@
                      (str "no nemesis can handle " (:f op))))
             (let [[fs nemesis] (first nemeses)]
               (if-let [f' (fs f)]
-                (client/invoke! nemesis test (assoc op :f f'))
+                (assoc (client/invoke! nemesis test (assoc op :f f')) :f f)
                 (recur (next nemeses))))))))
 
     (teardown! [this test]

--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -135,16 +135,16 @@
   not handle that :f, or a new :f, which replaces the op's :f, and the
   resulting op is passed to the given nemesis. For instance:
 
-      (compose #{:start :stop} (partition-random-halves)
-               #{:kill}        (process-killer))
+      (compose {#{:start :stop} (partition-random-halves)
+                #{:kill}        (process-killer)})
 
   This routes `:kill` ops to process killer, and :start/:stop to the
   partitioner. What if we had two partitioners which *both* take :start/:stop?
 
-      (compose {:split-start :start
-                :split-stop  :stop} (partition-random-halves)
-               {:ring-start  :start
-                :ring-stop2  :stop} (partition-majorities-ring))
+      (compose {{:split-start :start
+                 :split-stop  :stop} (partition-random-halves)
+                {:ring-start  :start
+                 :ring-stop2  :stop} (partition-majorities-ring)})
 
   We turn :split-start into :start, and pass that op to
   partition-random-halves."


### PR DESCRIPTION
Fix for the second recipe mentioned in the compose documentation.  I want to convert :xyz-start to :start keywords, etc.

Here is the assertion error that fails prior to this fix:

```
INFO  jepsen.util - :nemesis	:info	:start	"Cut off {\"n2\" #{\"n1\"}, \"n1\" #{\"n2\"}}"
WARN  jepsen.core - Nemesis crashed evaluating {:type :info, :f :partition-start, :process :nemesis, :time 7560628841}
java.lang.AssertionError: Assert failed: (= (:f op) (:f completion))
	at jepsen.core$nemesis_worker$fn__7855$fn__7860.invoke(core.clj:203)
	at jepsen.core$nemesis_worker$fn__7855.invoke(core.clj:195)
	at clojure.core$binding_conveyor_fn$fn__4444.invoke(core.clj:1916)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

Here is the code snippet:

```
           {:nemesis (nemesis/compose
                      {{:partition-start :start
                        :partition-stop :stop} (nemesis/partition-random-halves)
                       ;; TODO add more nemeses
                       })
```

https://github.com/norton/docker-datomic/blob/nemesis-compose/build/datomic-tester/jepsen.datomic/src/jepsen/datomic.clj#L219-L232
