### PR TITLE
jepsen.store: Ensure no concurrency issues for update-symlinks!

### DIFF
--- a/jepsen/src/jepsen/store.clj
+++ b/jepsen/src/jepsen/store.clj
@@ -242,10 +242,10 @@
   [test]
   (->> [(future (write-results! test))
         (future (write-history! test))
-        (future (write-fressian! test))
-        (future (update-symlinks! test))]
+        (future (write-fressian! test))]
        (map deref)
        dorun)
+  (update-symlinks! test)
   test)
 
 (defn delete-file-recursively!


### PR DESCRIPTION
Update the latest symlinks after all files have been created.  This issue is not always reproducible but does happen occasionally when running a series of jepson tests.