### PR TITLE
Fix wget "tries" option

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -37,7 +37,7 @@
   (let [filename (.getName (file url))]
     (when-not (file? filename)
       (exec :wget
-            :--retries 20
+            :--tries 20
             :--waitretry 60
             :--retry-connrefused
             :--dns-timeout 60


### PR DESCRIPTION
The option in wget should be "--tries" not "--retries"