### PR TITLE
Use pkill instead of killall, as it is supported on all Linux variants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ that (along with SSH username, password, identity files, etc) is all definable
 in your test. The account you use on those boxes needs sudo access to set up
 DBs, control firewalls, etc.
 
-Be advised that tests may mess with clocks, add apt repos, run killall -9 on
+Be advised that tests may mess with clocks, add apt repos, run pkill -9 on
 processes, and generally break things, so you shouldn't, you know, point jepsen
 at your prod machines unless you like to live dangerously, or you wrote the
 test and know exactly what it's doing.

--- a/aerospike/src/aerospike/core.clj
+++ b/aerospike/src/aerospike/core.clj
@@ -155,7 +155,7 @@
   (info node "stopping aerospike")
   (c/su
     (meh (c/exec :service :aerospike :stop))
-    (meh (c/exec :killall :-9 :asd))))
+    (meh (c/exec :pkill :-9 :asd))))
 
 (defn wipe!
   "Shuts down the server and wipes data."
@@ -355,7 +355,7 @@
   []
   (nemesis/node-start-stopper
     rand-nth
-    (fn start [test node] (c/su (c/exec :killall :-9 :asd)))
+    (fn start [test node] (c/su (c/exec :pkill :-9 :asd)))
     (fn stop  [test node] (start! node test))))
 
 ; Generators

--- a/chronos/src/jepsen/mesosphere.clj
+++ b/chronos/src/jepsen/mesosphere.clj
@@ -121,13 +121,13 @@
 (defn stop-master!
   [node]
   (info node "stopping mesos-master")
-  (meh (c/exec :killall :-9 :mesos-master))
+  (meh (c/exec :pkill :-9 :mesos-master))
   (meh (c/exec :rm :-rf master-pidfile)))
 
 (defn stop-slave!
   [node]
   (info node "stopping mesos-slave")
-  (meh (c/exec :killall :-9 :mesos-slave))
+  (meh (c/exec :pkill :-9 :mesos-slave))
   (meh (c/exec :rm :-rf slave-pidfile)))
 
 (defn db

--- a/consul/src/jepsen/consul.clj
+++ b/consul/src/jepsen/consul.clj
@@ -53,7 +53,7 @@
 
     (teardown! [_ test node]
       (c/su
-        (meh (c/exec :killall :-9 :consul))
+        (meh (c/exec :pkill :-9 :consul))
         (c/exec :rm :-rf pidfile data-dir))
       (info node "consul nuked"))))
 

--- a/disque/src/jepsen/disque.clj
+++ b/disque/src/jepsen/disque.clj
@@ -109,7 +109,7 @@
   [node]
   (info node "stopping disque")
   (c/su
-    (meh (c/exec :killall :-9 :disque-server))
+    (meh (c/exec :pkill :-9 :disque-server))
     (meh (c/exec :rm :-rf pidfile))))
 
 (defn wipe!

--- a/elasticsearch/src/elasticsearch/core.clj
+++ b/elasticsearch/src/elasticsearch/core.clj
@@ -146,7 +146,7 @@
   [node]
   (c/su
     (meh (c/exec :service :elasticsearch :stop))
-    (meh (c/exec :killall :-9 :elasticsearch)))
+    (meh (c/exec :pkill :-9 :elasticsearch)))
   (info node "elasticsearch stopped"))
 
 (defn nuke!
@@ -358,14 +358,14 @@
   "A nemesis that crashes a random subset of nodes."
   (nemesis/node-start-stopper
     mostly-small-nonempty-subset
-    (fn start [test node] (c/su (c/exec :killall :-9 :java)) [:killed node])
+    (fn start [test node] (c/su (c/exec :pkill :-9 :java)) [:killed node])
     (fn stop  [test node] (start! node) [:restarted node])))
 
 (def crash-primary-nemesis
   "A nemesis that crashes a random primary node."
   (nemesis/node-start-stopper
     (comp rand-nth self-primaries)
-    (fn start [test node] (c/su (c/exec :killall :-9 :java)) [:killed node])
+    (fn start [test node] (c/su (c/exec :pkill :-9 :java)) [:killed node])
     (fn stop  [test node] (start! node) [:restarted node])))
 
 (defn adds

--- a/etcd/src/jepsen/etcd.clj
+++ b/etcd/src/jepsen/etcd.clj
@@ -156,7 +156,7 @@
 
       (teardown! [_ test node]
         (c/su
-          (meh (c/exec :killall :-9 :etcd))
+          (meh (c/exec :pkill :-9 :etcd))
           (c/exec :rm :-rf pidfile data-dir log-file))
         (info node "etcd nuked")))))
 

--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -96,5 +96,5 @@
   "Kills a daemon process by command name, and cleans up pidfile."
   [cmd pidfile]
   (info "Stopping" cmd)
-  (meh (exec :killall :-9 cmd))
+  (meh (exec :pkill :-9 cmd))
   (meh (exec :rm :-rf pidfile)))

--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -236,8 +236,8 @@
   ([targeter process]
    (node-start-stopper targeter
                        (fn start [t n]
-                         (c/su (c/exec :killall :-s "STOP" process))
+                         (c/su (c/exec :pkill :-s "STOP" process))
                          [:paused process])
                        (fn stop [t n]
-                         (c/su (c/exec :killall :-s "CONT" process))
+                         (c/su (c/exec :pkill :-s "CONT" process))
                          [:resumed process]))))

--- a/rabbitmq/src/jepsen/rabbitmq.clj
+++ b/rabbitmq/src/jepsen/rabbitmq.clj
@@ -92,7 +92,7 @@
 ;        (meh (c/exec :rabbitmqctl :force_reset))
 ;        (meh (c/exec :service :rabbitmq-server :stop))
         (info node "Nuking rabbit")
-        (meh (c/exec :killall :-9 "beam.smp" "epmd"))
+        (meh (c/exec :pkill :-9 "beam.smp" "epmd"))
         (c/exec :rm :-rf "/var/lib/rabbitmq/mnesia/")
         (c/exec :service :rabbitmq-server :stop)
         (info node "Rabbit dead")))))

--- a/robustirc/src/jepsen/robustirc.clj
+++ b/robustirc/src/jepsen/robustirc.clj
@@ -25,7 +25,7 @@
   (reify db/DB
     (setup! [this test node]
       (c/su
-        (c/ssh* {:cmd "killall robustirc"})
+        (c/ssh* {:cmd "pkill robustirc"})
 	(try (c/exec :dpkg-query :-l :golang-go)
 	     (catch RuntimeException _
 	       (info "Installing golang-go")
@@ -80,7 +80,7 @@
 
     (teardown! [this test node]
       (c/su
-        (c/ssh* {:cmd "killall robustirc"}))
+        (c/ssh* {:cmd "pkill robustirc"}))
       )))
 
 (defn with-nemesis


### PR DESCRIPTION
Note - killall is not installed on an out of the box Ubuntu 14.04 host (not sure  about other Linux variants), it's in the psmisc package. It seems pkill is on the host. It might be better to support pkill than installing psmisc in jepsen/src/jepsen/os/debian.clj.