### PR TITLE
Wait in killall until all processes actually die.

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -177,5 +177,5 @@
 
   ([cmd pidfile]
    (info "Stopping" cmd)
-   (meh (exec :killall :-9 cmd))
+   (meh (exec :killall :-9 :-w cmd))
    (meh (exec :rm :-rf pidfile))))


### PR DESCRIPTION
The mongod process may take sometime to die after receiving the kill signal. We have seen this issue where the subsequent mongod failed to start because the socket was already in use.

Using the -w switch for killall should ensure that it is not longer running. Note, the killall command could hang if the process never terminates!

If this is not an optimal solution, then I suggest the stop-daemon function be modified to wait for all signaled processes to be terminated.