### PR TITLE
Check whether system was ever updated - fixing #134

### DIFF
--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -28,7 +28,7 @@
   "When did we last run an apt-get update, in seconds ago"
   []
   (- (Long/parseLong (c/exec :date "+%s"))
-     (Long/parseLong (c/exec :stat :-c "%Y" "/var/cache/apt/pkgcache.bin"))))
+     (Long/parseLong (c/exec :stat :-c "%Y" "/var/cache/apt/pkgcache.bin" "||" :echo 0))))
 
 (defn update!
   "Apt-get update."


### PR DESCRIPTION
A new debian system does not have `/var/cache/apt/pkgcache.bin` — so we should probably handle this case.