### PR TITLE
exclude 'docker' directory when we recursively tar up the jepsen root…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ bench/**
 */resources/datomic/download-key
 */resources/datomic/riak-transactor.properties
 /.nrepl-port
+.idea

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -66,7 +66,7 @@ INFO "Copying .. to control/jepsen"
 (
     rm -rf ./control/jepsen
     mkdir ./control/jepsen
-    (cd ..; tar cf - .)  | tar Cxf ./control/jepsen -
+    (cd ..; tar --exclude=./docker -cf - .)  | tar Cxf ./control/jepsen -
 )
 
 


### PR DESCRIPTION
… hierarchy and copy to ./docker/control/jepsen