### PR TITLE
MongoDB: "touch" log files before "cp" to make sure they exist and "c…

### DIFF
--- a/mongodb/src/jepsen/mongodb/core.clj
+++ b/mongodb/src/jepsen/mongodb/core.clj
@@ -88,6 +88,7 @@
   [node]
   (info node "copying mongod.log & stdout.log file to /root/")
   (c/su
+    (c/exec :touch "/opt/mongodb/mongod.log" "/opt/mongodb/stdout.log")
     (c/exec :cp :-f "/opt/mongodb/mongod.log" "/opt/mongodb/stdout.log" "/root/")))
 
 (defn wipe!


### PR DESCRIPTION
…p" succeeds